### PR TITLE
Add option to set defines as pytest arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ AnyPyTools Change Log
 
 **Removed:**
 
+v0.10.9
+=============
+
+** New: ** 
+
+-  Add option to the pytest plugin, to set the define statements with an argument to pytest.
+
 
 v0.10.8
 =============

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     'print_versions', 'execute_anybodycon',
 ]
 
-__version__ = '0.10.8'
+__version__ = '0.10.9'
 
 
 def print_versions():

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -341,6 +341,8 @@ class AnyItem(pytest.Item):
         test_name = '{}_{}'.format(name, id)
         super().__init__(test_name, parent)
         self.defs = defs
+        for k, v in self.config.getoption("define_kw"):
+            self.defs[k] = v
         self.defs['TEST_NAME'] = '"{}"'.format(test_name)
         if self.config.getoption("--ammr"):
             paths['AMMR_PATH'] = self.config.getoption("--ammr")
@@ -493,6 +495,10 @@ def pytest_addoption(parser):
     group.addoption("--only-load", action="store_true",
                     help="Only run a load test. I.e. do not run the "
                     "'RunTest' macro")
+    group.addoption("--define", action='append', 
+                    type=lambda kv: kv.split("=", 1), dest='define_kw',
+                    help="Add custom define statements parse to all AnyScript models. "
+                    "Must be given in the form: --define MYDEF=6")
     group._addoption("--timeout", default=3600, type=int,
                      help="terminate tests after a certain timeout period")
     tag = get_tag()

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -495,7 +495,7 @@ def pytest_addoption(parser):
     group.addoption("--only-load", action="store_true",
                     help="Only run a load test. I.e. do not run the "
                     "'RunTest' macro")
-    group.addoption("--define", action='append', 
+    group.addoption("--define", action='append',
                     type=lambda kv: kv.split("=", 1), dest='define_kw',
                     help="Add custom define statements parse to all AnyScript models. "
                     "Must be given in the form: --define MYDEF=6")


### PR DESCRIPTION
This updates the pytest plugin, so define statements can be set from the commandline. 

```
pytest --define MYDEF=1
```
This will set `#define MYDEF 1` in all models started by the pytest plugin. 