### PR TITLE
Fix define crash

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,15 @@ AnyPyTools Change Log
 
 **Removed:**
 
+v0.10.10
+=============
+
+** fixed: ** 
+
+-  Fix crash when ``--define`` option was not provided.
+
+
+
 v0.10.9
 =============
 

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     'print_versions', 'execute_anybodycon',
 ]
 
-__version__ = '0.10.9'
+__version__ = '0.10.10'
 
 
 def print_versions():

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -341,7 +341,7 @@ class AnyItem(pytest.Item):
         test_name = '{}_{}'.format(name, id)
         super().__init__(test_name, parent)
         self.defs = defs
-        for k, v in self.config.getoption("define_kw"):
+        for k, v in (self.config.getoption("define_kw") or {}):
             self.defs[k] = v
         self.defs['TEST_NAME'] = '"{}"'.format(test_name)
         if self.config.getoption("--ammr"):


### PR DESCRIPTION
This fixes a bug introduced in 0.10.9. The pytest plugin could crash when no arguments were given on the commandline. 