### PR TITLE
Fix ignore_errors with fatal warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ AnyPyTools Change Log
 
 - Missing newlines in error output from pytest plugin. 
 
+**Fixed:**
+
+- Fix a problem where the ``ignore_errors`` argument to :class:`AnyPyProcess()` could
+  not filter warnings when they were considered as errors with the ``fatal_warnings`` 
+  arguments. 
 
 
 v0.11.1

--- a/anypytools/abcutils.py
+++ b/anypytools/abcutils.py
@@ -275,13 +275,6 @@ class _Task(object):
         except KeyError:
             self.output['ERROR'] = [error_msg]
 
-    def add_warnings_to_error_list(self):
-        if 'WARNING' in self.output:
-            if self.has_error():
-                self.output['ERROR'].extend(self.output['WARNING'])
-            else:
-                self.output['ERROR'] = self.output['WARNING']
-
     def get_output(self, include_task_info=True):
         out = self.output
         if include_task_info:
@@ -803,7 +796,8 @@ class AnyPyProcess(object):
                     task.output = parse_anybodycon_output(
                         logfile.read(),
                         self.ignore_errors,
-                        self.warnings_to_include)
+                        self.warnings_to_include,
+                        fatal_warnings=self.fatal_warnings)
         except Exception as e:
             exc_type, exc_obj, exc_tb = sys.exc_info()
             fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
@@ -811,8 +805,6 @@ class AnyPyProcess(object):
                            '\n' + str(exc_tb.tb_lineno))
             logger.debug(str(e))
         finally:
-            if self.fatal_warnings:
-                task.add_warnings_to_error_list()
             if not self.keep_logfiles and not task.has_error():
                 try:
                     silentremove(logfile.name)

--- a/anypytools/tools.py
+++ b/anypytools/tools.py
@@ -588,9 +588,11 @@ DUMP_PATTERN = re.compile(r'^(Main.*?)\s=\s(.*?(?:\n\s\s.*?)*);', flags=re.M)
 
 
 def parse_anybodycon_output(raw, errors_to_ignore=None,
-                            warnings_to_include=None):
+                            warnings_to_include=None,
+                            fatal_warnings=False):
     """ Parse the output log file from AnyBodyConsole to
-        for data, errors and warnings
+        for data, errors and warnings. If fatal_warnins is
+        True, then warnings are also added to the error list.
     """
     warnings_to_include = warnings_to_include or []
     errors_to_ignore = errors_to_ignore or []
@@ -604,22 +606,28 @@ def parse_anybodycon_output(raw, errors_to_ignore=None,
             warnings.warn('\n\nCould not parse console output:\n' + name)
         output[name] = val
     error_list = []
-    # Find all errors in logfile
-    for match in ERROR_PATTERN.finditer(raw):
-        for case in errors_to_ignore:
-            if case in match.group(0):
+
+    def _add_non_ignored_errors(error_line):
+        for ignored_err in errors_to_ignore:
+            if ignored_err in error_line:
                 break
         else:
-            error_list.append(match.group(0))
-    if error_list:
-        output['ERROR'] = error_list
+            error_list.append(error_line)
+
+    # Find all errors in logfile
+    for match in ERROR_PATTERN.finditer(raw):
+        _add_non_ignored_errors(match.group(0))
     # Find all warnings in logfile
     warning_list = []
     for match in WARNING_PATTERN.finditer(raw):
         for case in warnings_to_include:
             if case in match.group(0):
+                if fatal_warnings:
+                    _add_non_ignored_errors(match.group(0))
                 warning_list.append(match.group(0))
                 break
+    if error_list:
+        output['ERROR'] = error_list
     if warning_list:
         output['WARNING'] = warning_list
     return output

--- a/anypytools/tools.py
+++ b/anypytools/tools.py
@@ -110,7 +110,7 @@ def wraptext(elem, initial_indent='', subsequent_indent=None):
     """Wraps text to fit the terminal window."""
     width = 120
     if sys.version_info.major == 3:
-        width = max(width, shutil.get_terminal_size().columns)
+        width = max(width, shutil.get_terminal_size().columns - 1)
     subsequent_indent = subsequent_indent or initial_indent
     return textwrap.fill(elem, width,
                          initial_indent=initial_indent,


### PR DESCRIPTION
Refactor the mechanism by which warnings are considered errors

It now happens directly when the log file is parsed. This makes
it possible to use the ``ignore_errors`` to ignore fatal warnings.