### PR TITLE
Fix regression for SetValue_random

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ AnyPyTools Change Log
 
 .. current developments
 
+**Fixed:**
+
+- Fix regression in for :class:`AnyPyTools.macro_comands.SetValue_random` which caused a 
+  crash when generating macros. 
+
 v0.12
 =============
 

--- a/anypytools/macroutils.py
+++ b/anypytools/macroutils.py
@@ -343,7 +343,7 @@ class SetValue_random(SetValue):
         if np.any(np.isnan(val)):
             val[np.isnan(val)] = self.rv.rvs()[np.isnan(val)]
 
-        return self.format_macro(val)
+        return self._format_macro(val)
 
 
 class Dump(MacroCommand):

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -53,7 +53,20 @@ def test_setvalue():
     
     c = mc.SetValue('val', np.array([[1,0],[0,1]]) )
     assert c.get_macro(0)  == 'classoperation val "Set Value" --value="{{1,0},{0,1}}"'
-    
+
+
+def test_setvalue_random():
+    np.random.seed(1)
+    fdist = norm(2, [1, 1, 1])
+
+    c = mc.SetValue_random('val', fdist)
+    assert c.get_macro(0) == 'classoperation val "Set Value" --value="{2,2,2}"'
+
+    mg = AnyMacro(c)
+    macrolist = mg.create_macros_MonteCarlo(2)
+    assert macrolist[0][0] == 'classoperation val "Set Value" --value="{2,2,2}"'
+    assert macrolist[1][0] == 'classoperation val "Set Value" --value="{1.79048215908,2.58380574427,-1.68494766954}"'
+
 
 def test_dump():
     c = mc.Dump('Main.Study.myvar1')


### PR DESCRIPTION
This fixes a regression which caused the SetValue_random class to crash when generating macros.

Thanks to @msan00 for finding this.