### PR TITLE
Add functionality to save hdf5 files when running tests

### DIFF
--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -9,7 +9,6 @@ import os
 import re
 import ast
 import shutil
-import pathlib
 import argparse
 import itertools
 import contextlib
@@ -443,7 +442,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--anytest-output",
         metavar="path",
-        default=pathlib.Path.cwd() / "anytest-output",
+        default=os.path.join(os.getcwd(), "anytest-output"),
         help="Specify a path to store the runs (when --anytest-save "
         "are used). Default: %(default)r.",
     )

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -248,10 +248,6 @@ class AnyItem(pytest.Item):
         self.name = test_name
         self.expect_errors = kwargs.get("expect_errors", [])
 
-        self.save_study = kwargs.get("save_study", "Main.Study")
-        if self.save_study is None:
-            pytest.anytest.save_hdf5_files = False
-
         self.timeout = self.config.getoption("--timeout")
         self.errors = []
         self.macro = [macro_commands.Load(self.fspath.strpath, self.defs, self.paths)]
@@ -271,7 +267,9 @@ class AnyItem(pytest.Item):
         }
         if not self.config.getoption("--only-load"):
             self.macro.append(macro_commands.OperationRun("Main.RunTest"))
-        if pytest.anytest.save_hdf5_files:
+
+        self.save_study = kwargs.get("save_study", "Main.Study")
+        if pytest.anytest.save_hdf5_files and self.save_study:
             # Add save operation to the test macro
             self.save_filename = pytest.anytest.get_save_fname(
                 name, id, self.save_study
@@ -389,7 +387,6 @@ class AnyException(Exception):
     """Custom exception for error reporting."""
 
 
-
 def pytest_addoption(parser):
     group = parser.getgroup("anypytools", "testing AnyBody models")
 
@@ -427,9 +424,7 @@ def pytest_addoption(parser):
         help="terminate tests after a certain timeout period",
     )
     group.addoption(
-        "--anytest-save",
-        action="store_true",
-        help="Save hdf5 files from tests.",
+        "--anytest-save", action="store_true", help="Save hdf5 files from tests."
     )
     # group.addoption(
     #     "--anytest-save-study",

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -60,8 +60,8 @@ class AnyTestSession(object):
         early in the pytest startup.
         """
         self.hdf5_save_folder = config.getoption("--anytest-output")
-        if os.path.exists(self.hdf5_save_folder):
-            shutil.rmtree(self.hdf5_save_folder, ignore_errors=True)
+        # if os.path.exists(self.hdf5_save_folder):
+        #     shutil.rmtree(self.hdf5_save_folder, ignore_errors=True)
         self.save_hdf5_files = config.getoption("--anytest-save")
 
         ammr_path = find_ammr_path(config.getoption("--ammr") or config.rootdir.strpath)
@@ -283,7 +283,10 @@ class AnyItem(pytest.Item):
         """Run an AnyScript test item."""
         tmpdir = self.config._tmpdirhandler.mktemp(self.name)
         if self.save_filename:
-            os.makedirs(os.path.dirname(self.save_filename))
+            dirname = os.path.dirname(self.save_filename)
+            if os.path.exists(dirname):
+                shutil.rmtree(dirname, ignore_errors=True)
+            os.makedirs(dirname)
         with change_dir(tmpdir.strpath):
             app = AnyPyProcess(**self.app_opts)
             result = app.start_macro(self.macro)[0]

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -60,7 +60,7 @@ class AnyTestSession(object):
         since it is instantiated and added to the pytest namespace very
         early in the pytest startup.
         """
-        self.hdf5_save_folder = config.getoption("--anytest-storage")
+        self.hdf5_save_folder = config.getoption("--anytest-output")
         if os.path.exists(self.hdf5_save_folder):
             shutil.rmtree(self.hdf5_save_folder, ignore_errors=True)
         self.save_hdf5_files = config.getoption("--anytest-save")
@@ -441,7 +441,7 @@ def pytest_addoption(parser):
         "easy to re-run the failed test in the gui application.",
     )
     group.addoption(
-        "--anytest-storage",
+        "--anytest-output",
         metavar="path",
         default=pathlib.Path.cwd() / "anytest-output",
         help="Specify a path to store the runs (when --anytest-save "

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -198,13 +198,9 @@ def pytest_collection_finish(session):
     print("\nUsing AnyBodyCon: ", pytest.anytest.ams_path)
 
 
-def pytest_namespace():
-    """Add an instance of the AnyTestSession class to the pytest name space."""
-    return {"anytest": AnyTestSession()}
-
-
 def pytest_configure(config):
     """Configure the AnyTest framework."""
+    pytest.anytest = AnyTestSession()
     pytest.anytest.configure(config)
 
 

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -39,6 +39,14 @@ def cwd(path):
         os.chdir(oldpwd)
 
 
+def pytest_xdist_setupnodes(config, specs):
+    """ called before any remote node is set up. """
+    print(
+        "\n\nUsing AnyBodyCon: ",
+        config.getoption("--anybodycon") or get_anybodycon_path(), "\n"
+    )
+
+
 class AnyTestSession(object):
     """Class for storing configuation of the AnyTest plugin to pytest."""
 

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -163,7 +163,7 @@ HEADER_ENSURES = (
     ("keep_logfiles", (bool,)),
     ("logfile_prefix", (str,)),
     ("expect_errors", (list,)),
-    ("save_study", (str,)),
+    ("save_study", (str,type(None))),
 )
 
 

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -70,8 +70,6 @@ class AnyTestSession(object):
             self.hdf5_save_folder = os.path.join(self.save_basefolder, self.save_name)
             if os.path.exists(self.hdf5_save_folder):
                 shutil.rmtree(self.hdf5_save_folder, ignore_errors=True)
-        self.save_name_study = config.getoption("--anytest-save-study")
-
         ammr_path = find_ammr_path(config.getoption("--ammr") or config.rootdir.strpath)
         self.ammr_version = get_ammr_version(ammr_path)
         self.ams_path = config.getoption("--anybodycon") or get_anybodycon_path()
@@ -254,9 +252,11 @@ class AnyItem(pytest.Item):
         self.paths = _as_absolute_paths(paths, start=self.config.rootdir.strpath)
         self.name = test_name
         self.expect_errors = kwargs.get("expect_errors", [])
-        self.save_study = pytest.anytest.save_name_study
-        if not self.save_study:
-            self.save_study = kwargs.get("save_study", "Main.Study")
+
+        self.save_study = kwargs.get("save_study", "Main.Study")
+        if self.save_study is None:
+            pytest.anytest.save_name = None
+
         self.timeout = self.config.getoption("--timeout")
         self.errors = []
         self.macro = [macro_commands.Load(self.fspath.strpath, self.defs, self.paths)]
@@ -445,12 +445,12 @@ def pytest_addoption(parser):
         type=parse_save_name,
         help="Save the current run into folder " "`~/.anytest/counter-NAME/`.",
     )
-    group.addoption(
-        "--anytest-save-study",
-        type=str,
-        help="Used to specify the study saved by the --anytest-save option. "
-        'Defaults to: "Main.Study" or what is set in the "test_*.any" file',
-    )
+    # group.addoption(
+    #     "--anytest-save-study",
+    #     type=str,
+    #     help="Used to specify the study saved by the --anytest-save option. "
+    #     'Defaults to: "Main.Study" or what is set in the "test_*.any" file',
+    # )
     group.addoption(
         "--create-macros",
         action="store_true",

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -144,9 +144,9 @@ def _format_switches(defs):
     elif isinstance(defs, list):
         pass
     else:
-        defs = [{}]
+        defs = [dict()]
     if len(defs) == 0:
-        defs = [{}]
+        defs = [dict()]
     return defs
 
 
@@ -163,11 +163,12 @@ HEADER_ENSURES = (
     ("keep_logfiles", (bool,)),
     ("logfile_prefix", (str,)),
     ("expect_errors", (list,)),
+    ("save_study", (str,)),
 )
 
 
 def _parse_header(header):
-    ns = {}
+    ns = dict()
     try:
         exec(header, globals(), ns)
     except SyntaxError:
@@ -209,11 +210,11 @@ class AnyFile(pytest.File):
         # Collect define statements from the header
         strheader = _read_header(self.fspath.strpath)
         header = _parse_header(strheader)
-        def_list = _format_switches(header.pop("define", {}))
+        def_list = _format_switches(header.pop("define", None))
         def_list = [
             replace_bm_constants(d, pytest.anytest.bm_constants_map) for d in def_list
         ]
-        path_list = _format_switches(header.pop("path", {}))
+        path_list = _format_switches(header.pop("path", None))
         combinations = itertools.product(def_list, path_list)
         # Run though the defines an create a test case for each
         for i, (defs, paths) in enumerate(combinations):

--- a/anypytools/tools.py
+++ b/anypytools/tools.py
@@ -52,7 +52,7 @@ def anybodycon_version(anybodyconpath):
     try:
         out = subprocess.check_output([anybodyconpath, "-ni"], universal_newlines=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
-        return None
+        return "0.0.0"
     m = ANYBODYCON_VERSION_RE.search(out)
     if m is not None:
         return m.groupdict()["version"]


### PR DESCRIPTION
This adds a feature to the pytest plugin to save the result of the model. 

The feature is activated by setting `--anytest-save`. The place where the hdf5 files are saved can be specified with: `--anytest-output`

The purpose of this feature is to easily generated data for comparing the simulation of two different models or the same model with a different version of AMS. 