### PR TITLE
Bug fix release 1.1.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 AnyPyTools Change Log
 =====================
 
+v1.1.4
+=============
+
+**Removed:**
+
+- Removed an ``--runslow`` argument in pytest plugin api. This setting caused problem when the user defined it them self. 
+
+
 v1.1.3
 =============
 

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -34,7 +34,7 @@ __all__ = [
     "NORMAL_PRIORITY_CLASS",
 ]
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 
 def print_versions():

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -434,9 +434,6 @@ def pytest_addoption(parser):
         help="Only run a load test. I.e. do not run the " "'RunTest' macro",
     )
     group.addoption(
-        "--runslow", action="store_true", default=False, help="run slow tests"
-    )
-    group.addoption(
         "--ammr",
         action="store",
         metavar="path",


### PR DESCRIPTION
This removes the "--runslow" argument in the pytest plugin which was accidentally released in 1.1.3