### PR TITLE
Simplify the interface for expected error in Pytest plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/Tutorial/Tutorial files/BatchProcess/Output/*
 docs/Tutorial/data.db.dat
 docs/Tutorial/data.db.dir
 docs/Tutorial/TestOutput.csv
+.vs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,20 @@
 AnyPyTools Change Log
 =====================
 
+v1.2.0
+=============
+
+**Added:**
+- Pytest plugin: Option to set the ``faltal_warnings`` variable as a list 
+  to select the warnings which should trigger an error. 
+
+
+**Removed:**
+
+- Pytest plugin: Deprecated the ``warnings_to_include`` variable. Instead use the `fatal_warnings` 
+  variable to select specific warnings.
+
+
 v1.1.5
 =============
 

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -34,7 +34,7 @@ __all__ = [
     "NORMAL_PRIORITY_CLASS",
 ]
 
-__version__ = "1.1.5"
+__version__ = "1.2.0"
 
 
 def print_versions():

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -280,7 +280,7 @@ class AnyItem(pytest.Item):
         fatal_warnings = kwargs.get("fatal_warnings", False)
         warnings_to_include = kwargs.get("warnings_to_include", None)
         if warnings_to_include:
-            warnings.war(
+            warnings.warn(
                 "`warnings_to_include` is deprecated. Specify the `fatal_warnings` variable as "
                 "a list to select specific warnings"
             )

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -161,7 +161,7 @@ HEADER_ENSURES = (
     ("path", (dict, collections.abc.Sequence)),
     ("ignore_errors", (collections.abc.Sequence,)),
     ("warnings_to_include", (collections.abc.Sequence,)),
-    ("fatal_warnings", (bool,collections.abc.Sequence)),
+    ("fatal_warnings", (bool, collections.abc.Sequence)),
     ("keep_logfiles", (bool,)),
     ("logfile_prefix", (str,)),
     ("expect_errors", (collections.abc.Sequence,)),
@@ -243,7 +243,7 @@ class AnyFile(pytest.File):
                     parent=self,
                     defs=defs,
                     paths=paths,
-                    **header
+                    **header,
                 )
             else:
                 raise ValueError("Malformed input: ", header)
@@ -265,8 +265,8 @@ class AnyItem(pytest.Item):
         self.paths = _as_absolute_paths(paths, start=self.config.rootdir.strpath)
         self.name = test_name
         self.expect_errors = kwargs.get("expect_errors", [])
-        
-        for marker in kwargs.get('pytest_markers', []):
+
+        for marker in kwargs.get("pytest_markers", []):
             self.add_marker(marker)
 
         self.timeout = self.config.getoption("--timeout")
@@ -276,19 +276,19 @@ class AnyItem(pytest.Item):
         self.macro_file = None
         self.anybodycon_path = pytest.anytest.ams_path
 
-
         fatal_warnings = kwargs.get("fatal_warnings", False)
         warnings_to_include = kwargs.get("warnings_to_include", None)
         if warnings_to_include:
             warnings.warn(
-                "`warnings_to_include` is deprecated. Specify the `fatal_warnings` variable as "
-                "a list to select specific warnings"
+                f"\n{name}:`warnings_to_include` is deprecated. \nSpecify the `fatal_warnings` variable as "
+                "a list to select specific warnings",
+                DeprecationWarning,
             )
             if not isinstance(fatal_warnings, collections.abc.Sequence):
                 fatal_warnings = warnings_to_include
 
         if not isinstance(fatal_warnings, collections.abc.Sequence):
-            fatal_warnings = ['WARNING'] if fatal_warnings else []
+            fatal_warnings = ["WARNING"] if fatal_warnings else []
 
         self.app_opts = {
             "return_task_info": True,


### PR DESCRIPTION
Adds an option to set the ``faltal_warnings`` variable as a list 
to select the warnings which should trigger an error. 

Deprecated the ``warnings_to_include`` variable. Instead, use the `fatal_warnings` 
variable to select specific warnings.
