### PR TITLE
Add workaround for bug in AMS<=7.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 AnyPyTools Change Log
 =====================
 
+v1.2.1
+=============
+
+**Fixed:**
+- Add a work-around for a bug in AnyBody < 7.2.2 which cause the AnyBody console  
+  to start in interactive mode when launched from AnyPyTools. This could cause the 
+  console application to hang if something fails in AnyBody. 
+
+
+
 v1.2.0
 =============
 

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -34,7 +34,7 @@ __all__ = [
     "NORMAL_PRIORITY_CLASS",
 ]
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 def print_versions():

--- a/anypytools/abcutils.py
+++ b/anypytools/abcutils.py
@@ -206,9 +206,9 @@ def execute_anybodycon(
         os.path.realpath(anybodycon_path),
         "--macro=",
         macro_file.name,
-        "/ni",
         "/deb",
         str(debug_mode),
+        "/ni",
     ]
     if sys.platform.startswith("win"):
         # Don't display the Windows GPF dialog if the invoked program dies.


### PR DESCRIPTION
This fixes a problem where AnyBody would start in interactive mode when launched from AnyPyTools. 