### PR TITLE
Handle NaN

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 AnyPyTools Change Log
 =====================
 
+v1.4.7
+=============
+Ensure that 'nan' values returned from AnyBody are treated as "float('nan')" when returned to Python.
+
+
+
 v1.4.6
 =============
 Fixed a bug when using explicit logfile arguments to ``start_macro`` did not work with the 

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -37,7 +37,7 @@ __all__ = [
     "NORMAL_PRIORITY_CLASS",
 ]
 
-__version__ = "1.4.6"
+__version__ = "1.4.7"
 
 
 def print_versions():


### PR DESCRIPTION
This adds the option to handle 'nan' (not a number) when they are returned from AnyBody. 

Before all arrays returned from AMS which contained a NaN would be treated as a array of strings. 

Now they are correctly treated as numbers. 