### PR TITLE
Fix to dataframe interpolation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,17 +29,16 @@ jobs:
     
     - name: Install conda
       run: | 
-        Invoke-Webrequest -URI https://anaconda.org/conda-forge/micromamba/0.15.2/download/win-64/micromamba-0.15.2-0.tar.bz2 -OutFile ~\micromamba.tar.bz2
-        (Get-FileHash ~\micromamba.tar.bz2).hash -eq "d406ee990640123b05b5b55a720720513d3ad8eed6d3377324e4842c6f141308"
-        $env:Path = "C:\PROGRA~1\Git\usr\bin;" + $env:Path
-        tar.exe -xvjf ~/micromamba.tar.bz2 --strip-components 2 -C ~ Library/bin/micromamba.exe
-        echo "MAMBA_ROOT_PREFIX=$HOME\micromamba" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          Invoke-Webrequest -URI https://anybodycloudci.blob.core.windows.net/micromamba/micromamba-0.25.1-0.tar.bz2 -OutFile ~\micromamba.tar.bz2
+          (Get-FileHash ~\micromamba.tar.bz2).hash -eq "ED3B12B747F05A630198D3A8A8F7120BDE22AE9033CB62AF95D6F3DF57FE9B0C"
+          $env:Path = "C:\PROGRA~1\Git\usr\bin;" + $env:Path
+          tar -xvjf ~/micromamba.tar.bz2 --strip-components 2 -C ~ Library/bin/micromamba.exe
+          echo "MAMBA_ROOT_PREFIX=$HOME\micromamba" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
       
     - name: Create conda environments
       run: |
         ~\micromamba.exe shell hook -s powershell | Out-String | iex
-        if (Test-Path -Path $Env:MAMBA_ROOT_PREFIX\envs\_anypytools) {$OPR = "update"} else {$OPR = "create"}
-        micromamba env $OPR -y -n _anypytools -f environment.yml
+        micromamba create --allow-downgrade -y -n _anypytools -f environment.yml
     
     - name: build
       run: |
@@ -51,7 +50,7 @@ jobs:
       run: |
         ~\micromamba.exe shell hook -s powershell | Out-String | iex
         micromamba activate _anypytools
-        micromamba install -y pytest -c conda-forge
+        micromamba install -y "pytest>=7" -c conda-forge
         pytest
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         ~\micromamba.exe shell hook -s powershell | Out-String | iex
         micromamba activate _anypytools
-        pip install --use-feature=in-tree-build .
+        pip install .
 
     - name: Test with pytest
       run: |
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install 
-        run: pip install --use-feature=in-tree-build .
+        run: pip install .
 
       - name: test
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # AnyPyTools Change Log
 
+## v1.8.2
+
+**Fixed:**
+- Fix a bug in {meth}`anypytools.tools.AnyPyProcessOutput.to_dataframe`    
+ function when also specifying interpolation. 
+  Now interpolation actually works again. Thanks to [Enrico De Pieri](https://github.com/depierie) and [Marc Bandi](https://github.com/marcbandi) for spotting and fixing this. 
+
 ## v1.8.1
 
 **Added:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## v1.8.2
 
 **Fixed:**
-- Fix a bug in {meth}`anypytools.tools.AnyPyProcessOutput.to_dataframe`    
- function when also specifying interpolation. 
+- Fix a bug in the {meth}`results.to_dataframe() <anypytools.tools.AnyPyProcessOutput.to_dataframe>` function when also specifying interpolation. 
   Now interpolation actually works again. Thanks to [Enrico De Pieri](https://github.com/depierie) and [Marc Bandi](https://github.com/marcbandi) for spotting and fixing this. 
 
 ## v1.8.1

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -37,7 +37,7 @@ __all__ = [
     "NORMAL_PRIORITY_CLASS",
 ]
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 
 
 def print_versions():

--- a/anypytools/abcutils.py
+++ b/anypytools/abcutils.py
@@ -259,7 +259,7 @@ def execute_anybodycon(
                 r"@exit /b %ERRORLEVEL%"
             )
             # Wine can have problems with arbitrary names. Create simple uniqe name for the file
-            hash_id = abs(hash(logfile.name)) % (10 ** 8)
+            hash_id = abs(hash(logfile.name)) % (10**8)
             batfile = macrofile_path.with_name(f"wine_{hash_id}.bat")
             batfile.write_text(anybodycmd)
             macrofile_cleanup.append(batfile)

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -469,6 +469,7 @@ class AnyTestItem(pytest.Item):
             return str(excinfo.value)
 
     def reportinfo(self):
+        """ """
         return self.path, 0, "AnyBody Simulation: %s" % self.name
 
 

--- a/anypytools/tools.py
+++ b/anypytools/tools.py
@@ -738,6 +738,7 @@ class AnyPyProcessOutput(collections.OrderedDict):
                 raise ValueError("The `interp_var` should not be a constant")
 
             dfout = dfout.set_index(interp_var, drop=True)
+            time_columns.remove(interp_var)
             dfout = dfout.reindex(dfout.index.union(interp_val))
             dfout[time_columns] = dfout[time_columns].interpolate(interp_method)
             dfout[constant_columns] = dfout[constant_columns].fillna(method="bfill")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -104,6 +104,28 @@ def test_AnyPyProcessOutput_to_dataframe():
     assert df3.shape == (1, 39)
 
 
+def test_AnyPyProcessOutput_to_dataframe_interp():
+    """Test that we can interpolate the data using 'Output.percent_var'
+    from 0 to 100
+    """
+    time_var = np.linspace(0, 4, 200)
+    data = {
+        "Output.Abscissa.t": time_var,
+        "Output.percent_var": np.linspace(-10, 140, len(time_var)),
+        "Output.SomeData": np.sin(time_var),
+        "contant": 0.38,
+        "contant_str": "Hello world",
+    }
+    anypydata = AnyPyProcessOutput(data)
+    interpolation_values = np.linspace(0, 99, 100)
+    df = anypydata.to_dataframe(
+        interp_var="Output.percent_var",
+        interp_val=interpolation_values,
+    )
+    assert df.shape == (100, 5)
+    assert all(df["Output.percent_var"] == interpolation_values)
+
+
 def test_AnyPyProcessOutputList_to_dataframe():
     time_len = 6
     no_simulations = 10


### PR DESCRIPTION
This fixes a bug in the `to_dataframe()` function which prevented interpolation from working. It also adds a test so the bug doesn't come back.

Finally, it update the version to prepare for a 1.8.2 release. 

fixes: #95 