### PR TITLE
Fix backwards compatibility with old AMMR (2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # AnyPyTools Change Log
 
+## v1.11.2
+
+**Fixed:**
+
+* Fix fix a backwards compatibiility problem when using the AnyPyTools Pytest plugin with 
+  old versions of AMMR (<2.3). 
+
 
 ## v1.11.1
 

--- a/anypytools/pytest_plugin.py
+++ b/anypytools/pytest_plugin.py
@@ -179,7 +179,7 @@ HEADER_ENSURES = (
     ("keep_logfiles", (bool,)),
     ("logfile_prefix", (str,)),
     ("expect_errors", (collections.abc.Sequence,)),
-    ("save_study", (str, collections.abc.Sequence)),
+    ("save_study", (str, collections.abc.Sequence, type(None))),
     ("pytest_markers", (collections.abc.Sequence,)),
     ("use_gui", (bool,)),
 )


### PR DESCRIPTION
This PR allows the "save_study" header variable in anysript test files to be "None". This was needed when using the new version of AnyPyTools with old version of the AMMR. 