### PR TITLE
Fix problem with pytest plugin when AnyBody is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AnyPyTools Change Log
 
+## v1.11.3
+
+**Fixed:**
+* Allow the pytest plugin to work even if the machine doesn't have AnyBody installed. 
+
+
 ## v1.11.2
 
 **Fixed:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## v1.11.3
 
+**Added:**
+
+* Correctly detect installations of AnyBody version 8 on the machines.
+
 **Fixed:**
+
 * Allow the pytest plugin to work even if the machine doesn't have AnyBody installed. 
 
 

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -37,7 +37,7 @@ __all__ = [
     "NORMAL_PRIORITY_CLASS",
 ]
 
-__version__ = "1.11.2"
+__version__ = "1.11.3"
 
 
 def print_versions():

--- a/anypytools/tools.py
+++ b/anypytools/tools.py
@@ -524,6 +524,21 @@ def _expand_short_path_name(short_path_name):
     return long_path_name
 
 
+def lookup_anybody_in_registry() -> str | None:
+    import winreg
+
+    try:
+        value = winreg.OpenKey(
+            winreg.HKEY_CLASSES_ROOT, "AnyBody.AnyScript\\shell\\open\\command"
+        )
+    except WindowsError:
+        warnings.warn("Could not locate AnyBody in registry")
+        return ""
+
+    anybodypath = value.rsplit(" ", 1)[0].strip('"')
+    return os.path.join(os.path.dirname(anybodypath), "AnyBodyCon.exe")
+
+
 def get_anybodycon_path() -> str | None:
     """Return the path to default AnyBody console application.
     If AnyBodyCon.exe is on path it will take precedence over
@@ -543,16 +558,7 @@ def get_anybodycon_path() -> str | None:
         else:
             return None
 
-    import winreg
-
-    try:
-        abpath = winreg.QueryValue(
-            winreg.HKEY_CLASSES_ROOT, "AnyBody.AnyScript\\shell\\open\\command"
-        )
-    except WindowsError:
-        raise WindowsError("Could not locate AnyBody in registry")
-    abpath = abpath.rsplit(" ", 1)[0].strip('"')
-    anybodycon_path = os.path.join(os.path.dirname(abpath), "AnyBodyCon.exe")
+    anybodycon_path = lookup_anybody_in_registry()
     if "~" in anybodycon_path:
         anybodycon_path = _expand_short_path_name(anybodycon_path)
     return anybodycon_path

--- a/anypytools/tools.py
+++ b/anypytools/tools.py
@@ -527,16 +527,20 @@ def _expand_short_path_name(short_path_name):
 def lookup_anybody_in_registry() -> str | None:
     import winreg
 
-    try:
-        value = winreg.OpenKey(
-            winreg.HKEY_CLASSES_ROOT, "AnyBody.AnyScript\\shell\\open\\command"
-        )
-    except WindowsError:
-        warnings.warn("Could not locate AnyBody in registry")
-        return ""
+    keys_to_try = [
+        "AnyBody.any\\shell\\open\\command",
+        "AnyBody.AnyScript\\shell\\open\\command",
+    ]
+    for key in keys_to_try:
+        try:
+            value = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, key)
+        except WindowsError:
+            continue
+        anybodypath = value.rsplit(" ", 1)[0].strip('"')
+        return os.path.join(os.path.dirname(anybodypath), "AnyBodyCon.exe")
 
-    anybodypath = value.rsplit(" ", 1)[0].strip('"')
-    return os.path.join(os.path.dirname(anybodypath), "AnyBodyCon.exe")
+    warnings.warn("Could not locate AnyBody in registry")
+    return ""
 
 
 def get_anybodycon_path() -> str | None:

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,1142 +1,941 @@
-version: 3
-metadata:
-  content_hash:
-    linux-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
-    win-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
-  channels:
-  - url: https://conda.anaconda.org/conda-forge/
-    used_env_vars: []
-  platforms:
-  - linux-64
-  - win-64
-  sources: []
-  time_metadata: null
-  git_metadata: null
-  inputs_metadata: null
-  custom_metadata: null
-package:
-- platform: linux-64
+version: 4
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/anybody/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h30efb56_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.23.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-0.8.0-py312h98912ed_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.7-py312h241aef2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py312h7900ff3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.10.0-nompi_py312h819072b_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.3.0-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.4.0-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.1-h783c2da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py312h98912ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.14-py312h4b3b743_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.2-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.3-py312hfb8ada1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloud_sptheme-1.10.1.post20200504175005-pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh31011fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.9.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-0.3.8-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments_anyscript-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.2.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/twine-4.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/anybody/win-64/anybodycon-8.0.0_Beta3-h9490d1a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cloud_sptheme-1.10.1.post20200504175005-pyhd8ed1ab_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh5737063_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.9.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-0.3.8-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments_anyscript-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.2.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/twine-4.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.11.17-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cmarkgfm-0.8.0-py311ha68e1ae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py311h1ea47a8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.10.0-nompi_py311h7195302_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/keyring-24.3.0-py311h1ea47a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.26-pthreads_hc140b1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.5-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.15-py311h633b200_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.0-py311hf63dbb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.2-py311h1ea47a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.12.0-py311h0b4df5a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+packages:
+- kind: conda
   name: _libgcc_mutex
   version: '0.1'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  hash:
-    md5: d7c89558ba9fa0495403155b64376d81
-    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   build: conda_forge
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  arch: x86_64
+  platform: linux
   license: None
   size: 2562
   timestamp: 1578324546067
-- platform: linux-64
+- kind: conda
   name: _openmp_mutex
   version: '4.5'
-  category: main
-  manager: conda
-  dependencies:
+  build: 2_gnu
+  build_number: 16
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
   - _libgcc_mutex 0.1 conda_forge
   - libgomp >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  hash:
-    md5: 73aaf86a425cc6e73fcf236a5a46396d
-    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  build: 2_gnu
-  arch: x86_64
-  subdir: linux-64
-  build_number: 16
   constrains:
   - openmp_impl 9999
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- platform: linux-64
+- kind: conda
   name: alabaster
   version: 0.7.13
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 06006184e203b61d3525f90de394471e
-    sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda
+  sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
+  md5: 06006184e203b61d3525f90de394471e
+  depends:
+  - python >=3.6
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 18154
   timestamp: 1673645756302
-- platform: win-64
-  name: alabaster
-  version: 0.7.13
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 06006184e203b61d3525f90de394471e
-    sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: anybodycon
+  version: 8.0.0_Beta3
+  build: h9490d1a_2
+  build_number: 2
   subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 18154
-  timestamp: 1673645756302
-- platform: linux-64
-  name: anypytools
-  version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - h5py >=2.5
-  - pydoe
-  - pygments_anyscript
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - scipy >=0.15
-  - setuptools
-  - tqdm
-  url: https://conda.anaconda.org/conda-forge/linux-64/anypytools-1.11.0-py312h7900ff3_0.conda
-  hash:
-    md5: 1d399575e0be393e2ac70c873633bf73
-    sha256: f59cf36ece6643706670fc8af610dfa24906bc70012ece53f3f914f843123c71
-  build: py312h7900ff3_0
+  url: https://conda.anaconda.org/anybody/win-64/anybodycon-8.0.0_Beta3-h9490d1a_2.tar.bz2
+  sha256: bab5bc0245968e3d3a0bed143b1dc403f54de71c56052f9a5eadd4075dee142e
+  md5: 159ed5fdbbb53ec49f5110072e3985e6
+  depends:
+  - python ==3.11
+  - nomkl
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 3076079
-  timestamp: 1701434835750
-- platform: win-64
-  name: anypytools
-  version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - h5py >=2.5
-  - pydoe
-  - pygments_anyscript
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - scipy >=0.15
-  - setuptools
-  - tqdm
-  url: https://conda.anaconda.org/conda-forge/win-64/anypytools-1.11.0-py312h2e8e312_0.conda
-  hash:
-    md5: b5712b1617827fbe2add43b14d7b5808
-    sha256: 32998f6e9806e9be8bdcd6f289cc880c58d6e48b31006e28df394de40b66809b
-  build: py312h2e8e312_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 3346527
-  timestamp: 1701435055226
-- platform: linux-64
+  platform: win
+  size: 187883760
+  timestamp: 1707207461195
+- kind: conda
   name: asttokens
   version: 2.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  - six >=1.12.0
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 28922
-  timestamp: 1698341257884
-- platform: win-64
-  name: asttokens
-  version: 2.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  - six >=1.12.0
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
+  sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
+  md5: 5f25798dcefd8252ce5f9dc494d5f571
+  depends:
+  - python >=3.5
+  - six >=1.12.0
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 28922
   timestamp: 1698341257884
-- platform: linux-64
+- kind: conda
   name: babel
   version: 2.13.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
+  sha256: 1f955c700db16f65b16c9e9c1613436480d5497970b8030b7a9ebe1620cc2147
+  md5: 3ccff479c246692468f604df9c85ef26
+  depends:
   - python >=3.7
   - pytz
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ccff479c246692468f604df9c85ef26
-    sha256: 1f955c700db16f65b16c9e9c1613436480d5497970b8030b7a9ebe1620cc2147
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 6948100
   timestamp: 1698174685067
-- platform: win-64
-  name: babel
-  version: 2.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - pytz
-  - setuptools
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ccff479c246692468f604df9c85ef26
-    sha256: 1f955c700db16f65b16c9e9c1613436480d5497970b8030b7a9ebe1620cc2147
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 6948100
-  timestamp: 1698174685067
-- platform: linux-64
+- kind: conda
   name: brotli-python
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h30efb56_1.conda
-  hash:
-    md5: 45801a89533d3336a365284d93298e36
-    sha256: b68706698b6ac0d31196a8bcb061f0d1f35264bcd967ea45e03e108149a74c6f
-  build: py312h30efb56_1
-  arch: x86_64
-  subdir: linux-64
+  build: py311h12c1d0e_1
   build_number: 1
-  constrains:
-  - libbrotlicommon 1.1.0 hd590300_1
-  license: MIT
-  license_family: MIT
-  size: 350604
-  timestamp: 1695990206327
-- platform: win-64
-  name: brotli-python
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
+  sha256: 5390e1e5e8e159d4893ecbfd2c08ca75ef51bdce1a4a44ff4ee9e2d596004aac
+  md5: 42fbf4e947c17ea605e6a4d7f526669a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h53d5487_1.conda
-  hash:
-    md5: d01a6667b99f0e8ad4097af66c938e62
-    sha256: 769e276ecdebf86f097786cbde1ebd11e018cd6cd838800995954fe6360e0797
-  build: py312h53d5487_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
   constrains:
   - libbrotlicommon 1.1.0 hcfcfb64_1
   license: MIT
   license_family: MIT
-  size: 322514
-  timestamp: 1695991054894
-- platform: linux-64
-  name: build
-  version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata
-  - packaging
-  - pep517 >=0.9.1
-  - python >=3.6
-  - tomli
-  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: add7f31586d03678695b32b78a1337a1
-    sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
-  build: pyhd8ed1ab_0
-  arch: x86_64
+  size: 322086
+  timestamp: 1695990976742
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py312h30efb56_1
+  build_number: 1
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 17759
-  timestamp: 1631843776429
-- platform: win-64
-  name: build
-  version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata
-  - packaging
-  - pep517 >=0.9.1
-  - python >=3.6
-  - tomli
-  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: add7f31586d03678695b32b78a1337a1
-    sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 17759
-  timestamp: 1631843776429
-- platform: linux-64
-  name: bzip2
-  version: 1.0.8
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h30efb56_1.conda
+  sha256: b68706698b6ac0d31196a8bcb061f0d1f35264bcd967ea45e03e108149a74c6f
+  md5: 45801a89533d3336a365284d93298e36
+  depends:
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-  hash:
-    md5: 69b8b6202a07720f448be700e300ccf4
-    sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
-  build: hd590300_5
+  - libstdcxx-ng >=12
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - libbrotlicommon 1.1.0 hd590300_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 254228
-  timestamp: 1699279927352
-- platform: win-64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 350604
+  timestamp: 1695990206327
+- kind: conda
+  name: build
+  version: 0.7.0
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
+  md5: add7f31586d03678695b32b78a1337a1
+  depends:
+  - importlib-metadata
+  - packaging
+  - pep517 >=0.9.1
+  - python >=3.6
+  - tomli
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 17759
+  timestamp: 1631843776429
+- kind: conda
   name: bzip2
   version: 1.0.8
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
+  sha256: ae5f47a5c86fd6db822931255dcf017eb12f60c77f07dc782ccb477f7808aab2
+  md5: 26eb8ca6ea332b675e11704cce84a3be
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
-  hash:
-    md5: 26eb8ca6ea332b675e11704cce84a3be
-    sha256: ae5f47a5c86fd6db822931255dcf017eb12f60c77f07dc782ccb477f7808aab2
-  build: hcfcfb64_5
   arch: x86_64
-  subdir: win-64
-  build_number: 5
+  platform: win
   license: bzip2-1.0.6
   license_family: BSD
   size: 124580
   timestamp: 1699280668742
-- platform: linux-64
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+  sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+  md5: 69b8b6202a07720f448be700e300ccf4
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 254228
+  timestamp: 1699279927352
+- kind: conda
   name: c-ares
   version: 1.23.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.23.0-hd590300_0.conda
-  hash:
-    md5: d459949bc10f64dee1595c176c2e6291
-    sha256: 6b0eee827bade11c2964a05867499a50ad2a9d1b14dfe18fb867a3bc9357f56f
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.23.0-hd590300_0.conda
+  sha256: 6b0eee827bade11c2964a05867499a50ad2a9d1b14dfe18fb867a3bc9357f56f
+  md5: d459949bc10f64dee1595c176c2e6291
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   size: 153627
   timestamp: 1701382098569
-- platform: linux-64
+- kind: conda
   name: ca-certificates
   version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
-  hash:
-    md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
-    sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
-  build: hbcca054_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: ISC
-  size: 154117
-  timestamp: 1700280881924
-- platform: win-64
-  name: ca-certificates
-  version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.11.17-h56e8100_0.conda
-  hash:
-    md5: 1163114b483f26761f993c709e65271f
-    sha256: c6177e2a4967db7a4e929c6ecd2fafde36e489dbeda23ceda640f4915cb0e877
   build: h56e8100_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.11.17-h56e8100_0.conda
+  sha256: c6177e2a4967db7a4e929c6ecd2fafde36e489dbeda23ceda640f4915cb0e877
+  md5: 1163114b483f26761f993c709e65271f
+  arch: x86_64
+  platform: win
   license: ISC
   size: 154700
   timestamp: 1700281021312
-- platform: linux-64
+- kind: conda
+  name: ca-certificates
+  version: 2023.11.17
+  build: hbcca054_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
+  sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
+  md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
+  arch: x86_64
+  platform: linux
+  license: ISC
+  size: 154117
+  timestamp: 1700280881924
+- kind: conda
   name: cached-property
   version: 1.5.2
-  category: main
-  manager: conda
-  dependencies:
-  - cached_property >=1.5.2,<1.5.3.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
   build: hd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  md5: 9b347a7ec10940d3f7941ff6c460b551
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 4134
   timestamp: 1615209571450
-- platform: win-64
-  name: cached-property
-  version: 1.5.2
-  category: main
-  manager: conda
-  dependencies:
-  - cached_property >=1.5.2,<1.5.3.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  build: hd8ed1ab_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 4134
-  timestamp: 1615209571450
-- platform: linux-64
+- kind: conda
   name: cached_property
   version: 1.5.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
   build: pyha770c72_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  md5: 576d629e47797577ab0f1b351297ef4a
+  depends:
+  - python >=3.6
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 11065
   timestamp: 1615209567874
-- platform: win-64
-  name: cached_property
-  version: 1.5.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
-  build: pyha770c72_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 11065
-  timestamp: 1615209567874
-- platform: linux-64
+- kind: conda
   name: certifi
   version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2011bcf45376341dd1d690263fdbc789
-    sha256: afa22b77128a812cb57bc707c297d926561bd225a3d9dd74205d87a3b2d14a96
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: ISC
-  noarch: python
-  size: 158939
-  timestamp: 1700303562512
-- platform: win-64
-  name: certifi
-  version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2011bcf45376341dd1d690263fdbc789
-    sha256: afa22b77128a812cb57bc707c297d926561bd225a3d9dd74205d87a3b2d14a96
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
-  license: ISC
   noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
+  sha256: afa22b77128a812cb57bc707c297d926561bd225a3d9dd74205d87a3b2d14a96
+  md5: 2011bcf45376341dd1d690263fdbc789
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: ISC
   size: 158939
   timestamp: 1700303562512
-- platform: linux-64
+- kind: conda
   name: cffi
   version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py311ha68e1ae_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
+  sha256: eb7463fe3785dd9ac0b3b1e5fea3b721d20eb082e194cab0af8d9ff28c28934f
+  md5: d109d6e767c4890ea32880b8bfa4a3b6
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 297043
+  timestamp: 1696002186279
+- kind: conda
+  name: cffi
+  version: 1.16.0
+  build: py312hf06ca03_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
+  sha256: 5a36e2c254603c367d26378fa3a205bd92263e30acf195f488749562b4c44251
+  md5: 56b0ca764ce23cc54f3f7e2a7b970f6d
+  depends:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - pycparser
   - python >=3.12.0rc3,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
-  hash:
-    md5: 56b0ca764ce23cc54f3f7e2a7b970f6d
-    sha256: 5a36e2c254603c367d26378fa3a205bd92263e30acf195f488749562b4c44251
-  build: py312hf06ca03_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 294523
   timestamp: 1696001868949
-- platform: win-64
-  name: cffi
-  version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
-  - pycparser
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+- kind: conda
+  name: charset-normalizer
+  version: 3.3.2
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  md5: 7f4a9e3fcff3f6356ae99244a014da6a
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
+  license: MIT
+  license_family: MIT
+  size: 46597
+  timestamp: 1698833765762
+- kind: conda
+  name: cloud_sptheme
+  version: 1.10.1.post20200504175005
+  build: pyhd8ed1ab_2
+  build_number: 2
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cloud_sptheme-1.10.1.post20200504175005-pyhd8ed1ab_2.tar.bz2
+  sha256: fdd0da00adba123108414c5d8cb8b173e8d085e48584ff2be9ff38ac1dfc88be
+  md5: d2329c1c16083425e647a393613cf40c
+  depends:
+  - jinja2
+  - markupsafe
+  - python >=2.7
+  - sphinx >=1.6
+  arch: x86_64
+  platform: win
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 75946
+  timestamp: 1648577656180
+- kind: conda
+  name: cmarkgfm
+  version: 0.8.0
+  build: py311ha68e1ae_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/cmarkgfm-0.8.0-py311ha68e1ae_3.conda
+  sha256: 8fe56f677ec4b47043170d2437ce020c204c88a56895c58490e89277af93a2ca
+  md5: 489e7c645da48b8c19f8232d70b45ec8
+  depends:
+  - cffi >=1.0.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py312he70551f_0.conda
-  hash:
-    md5: 5a51096925d52332c62bfd8904899055
-    sha256: dd39e594f5c6bca52dfed343de2af9326a99700ce2ba3404bd89706926fc0137
-  build: py312he70551f_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
   license: MIT
   license_family: MIT
-  size: 287805
-  timestamp: 1696002408940
-- platform: linux-64
-  name: charset-normalizer
-  version: 3.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 46597
-  timestamp: 1698833765762
-- platform: win-64
-  name: charset-normalizer
-  version: 3.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 46597
-  timestamp: 1698833765762
-- platform: linux-64
-  name: cloud_sptheme
-  version: 1.10.1.post20200504175005
-  category: main
-  manager: conda
-  dependencies:
-  - jinja2
-  - markupsafe
-  - python >=2.7
-  - sphinx >=1.6
-  url: https://conda.anaconda.org/conda-forge/noarch/cloud_sptheme-1.10.1.post20200504175005-pyhd8ed1ab_2.tar.bz2
-  hash:
-    md5: d2329c1c16083425e647a393613cf40c
-    sha256: fdd0da00adba123108414c5d8cb8b173e8d085e48584ff2be9ff38ac1dfc88be
-  build: pyhd8ed1ab_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 75946
-  timestamp: 1648577656180
-- platform: win-64
-  name: cloud_sptheme
-  version: 1.10.1.post20200504175005
-  category: main
-  manager: conda
-  dependencies:
-  - jinja2
-  - markupsafe
-  - python >=2.7
-  - sphinx >=1.6
-  url: https://conda.anaconda.org/conda-forge/noarch/cloud_sptheme-1.10.1.post20200504175005-pyhd8ed1ab_2.tar.bz2
-  hash:
-    md5: d2329c1c16083425e647a393613cf40c
-    sha256: fdd0da00adba123108414c5d8cb8b173e8d085e48584ff2be9ff38ac1dfc88be
-  build: pyhd8ed1ab_2
-  arch: x86_64
-  subdir: win-64
-  build_number: 2
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 75946
-  timestamp: 1648577656180
-- platform: linux-64
+  size: 120405
+  timestamp: 1695670523318
+- kind: conda
   name: cmarkgfm
   version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py312h98912ed_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-0.8.0-py312h98912ed_3.conda
+  sha256: 1a9e60b18664c22f872435a1d2b1d727e37ea4159736b116afff364b9577dc02
+  md5: 0c9c09134b2fb151c2bd8181b2c56080
+  depends:
   - cffi >=1.0.0
   - libgcc-ng >=12
   - python >=3.12.0rc3,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-0.8.0-py312h98912ed_3.conda
-  hash:
-    md5: 0c9c09134b2fb151c2bd8181b2c56080
-    sha256: 1a9e60b18664c22f872435a1d2b1d727e37ea4159736b116afff364b9577dc02
-  build: py312h98912ed_3
   arch: x86_64
-  subdir: linux-64
-  build_number: 3
+  platform: linux
   license: MIT
   license_family: MIT
   size: 135963
   timestamp: 1695669875921
-- platform: win-64
-  name: cmarkgfm
-  version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - cffi >=1.0.0
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/cmarkgfm-0.8.0-py312he70551f_3.conda
-  hash:
-    md5: c02f42cc7c74c6dcac910f3aec3d3e6b
-    sha256: 9f5bdfbd843e58bfc727ae5a8b07079c2700d5579f0eef1e8c85aa4fa0ac5fa3
-  build: py312he70551f_3
-  arch: x86_64
-  subdir: win-64
-  build_number: 3
-  license: MIT
-  license_family: MIT
-  size: 119774
-  timestamp: 1695670282391
-- platform: linux-64
+- kind: conda
   name: colorama
   version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 25170
   timestamp: 1666700778190
-- platform: win-64
-  name: colorama
-  version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 25170
-  timestamp: 1666700778190
-- platform: linux-64
+- kind: conda
   name: comm
   version: 0.1.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: c8eaca39e2b6abae1fc96acc929ae939
-    sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 11682
-  timestamp: 1691045097208
-- platform: win-64
-  name: comm
-  version: 0.1.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: c8eaca39e2b6abae1fc96acc929ae939
-    sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
+  sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
+  md5: c8eaca39e2b6abae1fc96acc929ae939
+  depends:
+  - python >=3.6
+  - traitlets >=5.3
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 11682
   timestamp: 1691045097208
-- platform: linux-64
+- kind: conda
   name: cryptography
   version: 41.0.7
-  category: main
-  manager: conda
-  dependencies:
+  build: py312h241aef2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.7-py312h241aef2_0.conda
+  sha256: 34e9130e0dbee5ab2949d4d9aa73afd05b9553227946f941053fde4f7cff1188
+  md5: b887fd97600b97c4ea5cda5f3c9ebe3c
+  depends:
   - cffi >=1.12
   - libgcc-ng >=12
   - openssl >=3.2.0,<4.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.7-py312h241aef2_0.conda
-  hash:
-    md5: b887fd97600b97c4ea5cda5f3c9ebe3c
-    sha256: 34e9130e0dbee5ab2949d4d9aa73afd05b9553227946f941053fde4f7cff1188
-  build: py312h241aef2_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   size: 2038938
   timestamp: 1701145503964
-- platform: linux-64
+- kind: conda
   name: dbus
   version: 1.13.6
-  category: main
-  manager: conda
-  dependencies:
+  build: h5008d03_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+  sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
+  md5: ecfff944ba3960ecb334b9a2663d708d
+  depends:
   - expat >=2.4.2,<3.0a0
   - libgcc-ng >=9.4.0
   - libglib >=2.70.2,<3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
-  hash:
-    md5: ecfff944ba3960ecb334b9a2663d708d
-    sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
-  build: h5008d03_3
   arch: x86_64
-  subdir: linux-64
-  build_number: 3
+  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL
   size: 618596
   timestamp: 1640112124844
-- platform: linux-64
+- kind: conda
   name: decorator
   version: 5.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 12072
-  timestamp: 1641555714315
-- platform: win-64
-  name: decorator
-  version: 5.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+  md5: 43afe5ab04e35e17ba28649471dd7364
+  depends:
+  - python >=3.5
+  arch: x86_64
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 12072
   timestamp: 1641555714315
-- platform: linux-64
+- kind: conda
   name: docutils
   version: 0.20.1
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h1ea47a8_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py311h1ea47a8_3.conda
+  sha256: fcce275ca03558a4feab18964ee1368f529fe095304a3a99b22e34459a4c0090
+  md5: 53e577542ed0df5a3af146e4a746dbd9
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 973107
+  timestamp: 1701883312560
+- kind: conda
+  name: docutils
+  version: 0.20.1
+  build: py312h7900ff3_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py312h7900ff3_2.conda
+  sha256: bade342768729e2e1f014d62f7c6c17db012ffe718e341274ce9f232d34383d4
+  md5: 5e9bf8f7126528bea5c31f42ceebc06c
+  depends:
   - python >=3.12.0rc3,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py312h7900ff3_2.conda
-  hash:
-    md5: 5e9bf8f7126528bea5c31f42ceebc06c
-    sha256: bade342768729e2e1f014d62f7c6c17db012ffe718e341274ce9f232d34383d4
-  build: py312h7900ff3_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: LicenseRef-Public-Domain-Dedictation AND BSD-3-Clause AND BSD-2-Clause AND LicenseRef-PSF-2.1.1
   size: 897287
   timestamp: 1695300608494
-- platform: win-64
-  name: docutils
-  version: 0.20.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py312h2e8e312_2.conda
-  hash:
-    md5: f8e0b1c2a2f0d3bfe45a6e7674576632
-    sha256: 7a802cd0a2535a021e6653b2bc16f0c046cc1adfdd3f40d4ceb0e8511cd6e69e
-  build: py312h2e8e312_2
-  arch: x86_64
-  subdir: win-64
-  build_number: 2
-  license: LicenseRef-Public-Domain-Dedictation AND BSD-3-Clause AND BSD-2-Clause AND LicenseRef-PSF-2.1.1
-  size: 950891
-  timestamp: 1695300854692
-- platform: linux-64
+- kind: conda
   name: exceptiongroup
   version: 1.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f6c211fee3c98229652b60a9a42ef363
-    sha256: cf83dcaf9006015c8ccab3fc6770f478464a66a8769e1763ca5d7dff09d11d08
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_0.conda
+  sha256: cf83dcaf9006015c8ccab3fc6770f478464a66a8769e1763ca5d7dff09d11d08
+  md5: f6c211fee3c98229652b60a9a42ef363
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 20473
   timestamp: 1700579932017
-- platform: win-64
-  name: exceptiongroup
-  version: 1.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f6c211fee3c98229652b60a9a42ef363
-    sha256: cf83dcaf9006015c8ccab3fc6770f478464a66a8769e1763ca5d7dff09d11d08
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 20473
-  timestamp: 1700579932017
-- platform: linux-64
+- kind: conda
   name: execnet
   version: 2.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67de0d8241e1060a479e3c37793e26f9
-    sha256: 88ea68a360198af39368beecf057af6b31f0ae38071b2bdb2aa961b6ae5427c0
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.0.2-pyhd8ed1ab_0.conda
+  sha256: 88ea68a360198af39368beecf057af6b31f0ae38071b2bdb2aa961b6ae5427c0
+  md5: 67de0d8241e1060a479e3c37793e26f9
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 36534
   timestamp: 1688933537234
-- platform: win-64
-  name: execnet
-  version: 2.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67de0d8241e1060a479e3c37793e26f9
-    sha256: 88ea68a360198af39368beecf057af6b31f0ae38071b2bdb2aa961b6ae5427c0
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 36534
-  timestamp: 1688933537234
-- platform: linux-64
+- kind: conda
   name: executing
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 27689
-  timestamp: 1698580072627
-- platform: win-64
-  name: executing
-  version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
+  sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
+  md5: e16be50e378d8a4533b989035b196ab8
+  depends:
+  - python >=2.7
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 27689
   timestamp: 1698580072627
-- platform: linux-64
+- kind: conda
   name: expat
   version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcb278e6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+  sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
+  md5: 8b9b5aca60558d02ddaa09d599e55920
+  depends:
   - libexpat 2.5.0 hcb278e6_1
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 8b9b5aca60558d02ddaa09d599e55920
-    sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  build: hcb278e6_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: MIT
   license_family: MIT
   size: 136778
   timestamp: 1680190541750
-- platform: linux-64
+- kind: conda
   name: gettext
   version: 0.21.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-  hash:
-    md5: 14947d8770185e5153fdd04d4673ed37
-    sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
   build: h27087fc_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+  sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
+  md5: 14947d8770185e5153fdd04d4673ed37
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 4320628
   timestamp: 1665673494324
-- platform: linux-64
+- kind: conda
   name: h5py
   version: 3.10.0
-  category: main
-  manager: conda
-  dependencies:
+  build: nompi_py311h7195302_101
+  build_number: 101
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/h5py-3.10.0-nompi_py311h7195302_101.conda
+  sha256: 3232aec21a01bb5f491bd4df54eec72035339e36937399358254cf61a974fdc1
+  md5: 04c8294a0d1748d24d5071c777aa2572
+  depends:
+  - cached-property
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 966559
+  timestamp: 1702473291034
+- kind: conda
+  name: h5py
+  version: 3.10.0
+  build: nompi_py312h819072b_100
+  build_number: 100
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.10.0-nompi_py312h819072b_100.conda
+  sha256: 4fcf5ed56c47dee0e1b3d123633c5516ea48ea3b34594f5fe0a25d94d138d478
+  md5: 46df08418cfe61b752b09ebfc26645b1
+  depends:
   - cached-property
   - hdf5 >=1.14.2,<1.14.3.0a0
   - libgcc-ng >=12
   - numpy >=1.26.0,<2.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.10.0-nompi_py312h819072b_100.conda
-  hash:
-    md5: 46df08418cfe61b752b09ebfc26645b1
-    sha256: 4fcf5ed56c47dee0e1b3d123633c5516ea48ea3b34594f5fe0a25d94d138d478
-  build: nompi_py312h819072b_100
   arch: x86_64
-  subdir: linux-64
-  build_number: 100
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 1236411
   timestamp: 1696885556726
-- platform: win-64
-  name: h5py
-  version: 3.10.0
-  category: main
-  manager: conda
-  dependencies:
-  - cached-property
-  - hdf5 >=1.14.2,<1.14.3.0a0
-  - numpy >=1.26.0,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/h5py-3.10.0-nompi_py312h2ee7e95_100.conda
-  hash:
-    md5: 16eeee0b2b704e44eb0f4e98f40f45d5
-    sha256: 48cca382c3ed1ba246a30d6cf247b54505167e18fab1a9e14f3c8556778f6319
-  build: nompi_py312h2ee7e95_100
-  arch: x86_64
-  subdir: win-64
-  build_number: 100
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 937186
-  timestamp: 1696888164219
-- platform: linux-64
+- kind: conda
   name: hdf5
   version: 1.14.2
-  category: main
-  manager: conda
-  dependencies:
+  build: nompi_h4f84152_100
+  build_number: 100
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
+  sha256: f70f18291f912ba019cbb736bb87b6487021154733cd109147a6d9672790b6b8
+  md5: 2de6a9bc8083b49f09b2f6eb28d3ba3c
+  depends:
   - libaec >=1.0.6,<2.0a0
   - libcurl >=8.2.1,<9.0a0
   - libgcc-ng >=12
@@ -1145,269 +944,130 @@ package:
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.2,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
-  hash:
-    md5: 2de6a9bc8083b49f09b2f6eb28d3ba3c
-    sha256: f70f18291f912ba019cbb736bb87b6487021154733cd109147a6d9672790b6b8
-  build: nompi_h4f84152_100
   arch: x86_64
-  subdir: linux-64
-  build_number: 100
+  platform: linux
   license: LicenseRef-HDF5
   license_family: BSD
   size: 3726636
   timestamp: 1692563074131
-- platform: win-64
+- kind: conda
   name: hdf5
-  version: 1.14.2
-  category: main
-  manager: conda
-  dependencies:
-  - libaec >=1.0.6,<2.0a0
-  - libcurl >=8.2.1,<9.0a0
+  version: 1.14.3
+  build: nompi_h73e8ff5_100
+  build_number: 100
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
+  sha256: 89bbb2c878e1b6c6073ef5f1f25eac97ed48393541a4a44a7d182da5ede3dc98
+  md5: 1e91ce0f3a914b0dab762539c0df4ff1
+  depends:
+  - libaec >=1.1.2,<2.0a0
+  - libcurl >=8.4.0,<9.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
-  hash:
-    md5: 7fc095c23e4519a8df15c09f3671d09a
-    sha256: 86bab02f1dbc658a15719b27ca5dcd2b50c22905cc2296a31a0ed220dac746f9
-  build: nompi_h73e8ff5_100
-  arch: x86_64
-  subdir: win-64
-  build_number: 100
   license: LicenseRef-HDF5
   license_family: BSD
-  size: 2044096
-  timestamp: 1692562772245
-- platform: linux-64
+  size: 2045774
+  timestamp: 1701791365837
+- kind: conda
   name: idna
   version: '3.6'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1a76f09108576397c41c0b0c5bd84134
-    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+  sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
+  md5: 1a76f09108576397c41c0b0c5bd84134
+  depends:
+  - python >=3.6
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 50124
   timestamp: 1701027126206
-- platform: win-64
-  name: idna
-  version: '3.6'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1a76f09108576397c41c0b0c5bd84134
-    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 50124
-  timestamp: 1701027126206
-- platform: linux-64
+- kind: conda
   name: imagesize
   version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 7de5386c8fea29e76b303f37dde4c352
-    sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
+  sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+  md5: 7de5386c8fea29e76b303f37dde4c352
+  depends:
+  - python >=3.4
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 10164
   timestamp: 1656939625410
-- platform: win-64
-  name: imagesize
-  version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 7de5386c8fea29e76b303f37dde4c352
-    sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 10164
-  timestamp: 1656939625410
-- platform: linux-64
+- kind: conda
   name: importlib-metadata
   version: 6.8.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyha770c72_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+  sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
+  md5: 4e9f59a060c3be52bc4ddc46ee9b6946
+  depends:
   - python >=3.8
   - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
-  hash:
-    md5: 4e9f59a060c3be52bc4ddc46ee9b6946
-    sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  build: pyha770c72_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 25910
   timestamp: 1688754651944
-- platform: win-64
-  name: importlib-metadata
-  version: 6.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
-  hash:
-    md5: 4e9f59a060c3be52bc4ddc46ee9b6946
-    sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 25910
-  timestamp: 1688754651944
-- platform: linux-64
+- kind: conda
   name: importlib_metadata
   version: 6.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=6.8.0,<6.8.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: b279b07ce18058034e5b3606ba103a8b
-    sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
   build: hd8ed1ab_0
+  subdir: win-64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+  sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
+  md5: b279b07ce18058034e5b3606ba103a8b
+  depends:
+  - importlib-metadata >=6.8.0,<6.8.1.0a0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: generic
   size: 9428
   timestamp: 1688754660209
-- platform: win-64
-  name: importlib_metadata
-  version: 6.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=6.8.0,<6.8.1.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
-  hash:
-    md5: b279b07ce18058034e5b3606ba103a8b
-    sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
-  build: hd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: generic
-  size: 9428
-  timestamp: 1688754660209
-- platform: linux-64
+- kind: conda
   name: iniconfig
   version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+  md5: f800d2da156d08e289b14e87e43c1ae5
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 11101
   timestamp: 1673103208955
-- platform: win-64
-  name: iniconfig
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f800d2da156d08e289b14e87e43c1ae5
-    sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 11101
-  timestamp: 1673103208955
-- platform: win-64
-  name: intel-openmp
-  version: 2023.2.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
-  hash:
-    md5: a401f3cae152deb75bbed766a90a6312
-    sha256: dd9fded25ebe5c66af30ac6e3685146efdc2d7787035f01bfb546b347f138f6f
-  build: h57928b3_50497
-  arch: x86_64
-  subdir: win-64
-  build_number: 50497
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 2523079
-  timestamp: 1698351323119
-- platform: linux-64
+- kind: conda
   name: ipython
   version: 8.18.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyh31011fe_1
+  build_number: 1
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh31011fe_1.conda
+  sha256: 67490e640faa372d663a5c5cd2d61f417cce22a019a4de82a9e5ddb1cf2ee181
+  md5: ac2f9c2e10c2e90e8d135cef51f9753a
+  depends:
   - __unix
   - decorator
   - exceptiongroup
@@ -1421,25 +1081,23 @@ package:
   - stack_data
   - traitlets >=5
   - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh31011fe_1.conda
-  hash:
-    md5: ac2f9c2e10c2e90e8d135cef51f9753a
-    sha256: 67490e640faa372d663a5c5cd2d61f417cce22a019a4de82a9e5ddb1cf2ee181
-  build: pyh31011fe_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 590243
   timestamp: 1701092540336
-- platform: win-64
+- kind: conda
   name: ipython
   version: 8.18.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyh5737063_1
+  build_number: 1
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh5737063_1.conda
+  sha256: 15cc7e64ada322f517a3033a7586115c90693eb5da40349f9bbaf728ef17295d
+  md5: 2d6efe4b70b555e766b544e4c8b39a8b
+  depends:
   - __win
   - colorama
   - decorator
@@ -1453,530 +1111,367 @@ package:
   - stack_data
   - traitlets >=5
   - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.18.1-pyh5737063_1.conda
-  hash:
-    md5: 2d6efe4b70b555e766b544e4c8b39a8b
-    sha256: 15cc7e64ada322f517a3033a7586115c90693eb5da40349f9bbaf728ef17295d
-  build: pyh5737063_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 591332
   timestamp: 1701093094777
-- platform: linux-64
+- kind: conda
   name: ipywidgets
   version: 8.1.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
+  sha256: 8136defec115396ba992273a77f814d74eeafd9cc099f5430d109c60785a7f02
+  md5: 2605fae5ee27100e5f10037baebf4d41
+  depends:
   - comm >=0.1.3
   - ipython >=6.1.0
   - jupyterlab_widgets >=3.0.9,<3.1.0
   - python >=3.7
   - traitlets >=4.3.1
   - widgetsnbextension >=4.0.9,<4.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2605fae5ee27100e5f10037baebf4d41
-    sha256: 8136defec115396ba992273a77f814d74eeafd9cc099f5430d109c60785a7f02
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 114155
   timestamp: 1694607285777
-- platform: win-64
-  name: ipywidgets
-  version: 8.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - comm >=0.1.3
-  - ipython >=6.1.0
-  - jupyterlab_widgets >=3.0.9,<3.1.0
-  - python >=3.7
-  - traitlets >=4.3.1
-  - widgetsnbextension >=4.0.9,<4.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2605fae5ee27100e5f10037baebf4d41
-    sha256: 8136defec115396ba992273a77f814d74eeafd9cc099f5430d109c60785a7f02
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 114155
-  timestamp: 1694607285777
-- platform: linux-64
+- kind: conda
   name: jaraco.classes
   version: 3.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.0-pyhd8ed1ab_0.conda
+  sha256: 14f5240c3834e1b784dd41a5a14392d9150dff62a74ae851f73e65d2e2bbd891
+  md5: e9f79248d30e942f7c358ff21a1790f5
+  depends:
   - more-itertools
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e9f79248d30e942f7c358ff21a1790f5
-    sha256: 14f5240c3834e1b784dd41a5a14392d9150dff62a74ae851f73e65d2e2bbd891
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 11288
   timestamp: 1689112573324
-- platform: win-64
-  name: jaraco.classes
-  version: 3.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - more-itertools
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e9f79248d30e942f7c358ff21a1790f5
-    sha256: 14f5240c3834e1b784dd41a5a14392d9150dff62a74ae851f73e65d2e2bbd891
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 11288
-  timestamp: 1689112573324
-- platform: linux-64
+- kind: conda
   name: jedi
   version: 0.19.1
-  category: main
-  manager: conda
-  dependencies:
-  - parso >=0.8.3,<0.9.0
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 841312
-  timestamp: 1696326218364
-- platform: win-64
-  name: jedi
-  version: 0.19.1
-  category: main
-  manager: conda
-  dependencies:
-  - parso >=0.8.3,<0.9.0
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  md5: 81a3be0b2023e1ea8555781f0ad904a2
+  depends:
+  - parso >=0.8.3,<0.9.0
+  - python >=3.6
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 841312
   timestamp: 1696326218364
-- platform: linux-64
+- kind: conda
   name: jeepney
   version: 0.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9800ad1699b42612478755a2d26c722d
-    sha256: 16639759b811866d63315fe1391f6fb45f5478b823972f4d3d9f0392b7dd80b8
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 16639759b811866d63315fe1391f6fb45f5478b823972f4d3d9f0392b7dd80b8
+  md5: 9800ad1699b42612478755a2d26c722d
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  noarch: python
   size: 36895
   timestamp: 1649085298891
-- platform: linux-64
+- kind: conda
   name: jinja2
   version: 3.1.2
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
+  sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+  md5: c8490ed5c70966d232fdd389d0dbed37
+  depends:
   - markupsafe >=2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  build: pyhd8ed1ab_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 101443
   timestamp: 1654302514195
-- platform: win-64
-  name: jinja2
-  version: 3.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - markupsafe >=2.0
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c8490ed5c70966d232fdd389d0dbed37
-    sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 101443
-  timestamp: 1654302514195
-- platform: linux-64
+- kind: conda
   name: jupyterlab_widgets
   version: 3.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8370e0a9dc443f9b45a23fd30e7a6b3b
-    sha256: ec66991d2175f7b1f35973d6c4f56ad9a49666f77acf1037d72f3bc6e37224f3
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - jupyterlab >=3,<5
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 186821
-  timestamp: 1694598854365
-- platform: win-64
-  name: jupyterlab_widgets
-  version: 3.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8370e0a9dc443f9b45a23fd30e7a6b3b
-    sha256: ec66991d2175f7b1f35973d6c4f56ad9a49666f77acf1037d72f3bc6e37224f3
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
+  sha256: ec66991d2175f7b1f35973d6c4f56ad9a49666f77acf1037d72f3bc6e37224f3
+  md5: 8370e0a9dc443f9b45a23fd30e7a6b3b
+  depends:
+  - python >=3.7
   constrains:
   - jupyterlab >=3,<5
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 186821
   timestamp: 1694598854365
-- platform: linux-64
+- kind: conda
   name: keyring
   version: 24.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py311h1ea47a8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/keyring-24.3.0-py311h1ea47a8_0.conda
+  sha256: 31a737db3d02c5ab7a63f4d9da6f8cc73d76df9e0c41c9057b1cd631526aca8d
+  md5: 36b1b2b2889d253cb8bb0b80a9cb1493
+  depends:
+  - importlib_metadata >=4.11.4
+  - jaraco.classes
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - pywin32-ctypes >=0.2.0
+  license: MIT
+  license_family: MIT
+  size: 94691
+  timestamp: 1699924273245
+- kind: conda
+  name: keyring
+  version: 24.3.0
+  build: py312h7900ff3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.3.0-py312h7900ff3_0.conda
+  sha256: 312656da4f0b4b0aacee5914735fdc781bc8412edee6cc90b937a279975d8b1e
+  md5: c303e2ddfc697a70a137940f8a6b2e1d
+  depends:
   - jaraco.classes
   - jeepney >=0.4.2
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - secretstorage >=3.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.3.0-py312h7900ff3_0.conda
-  hash:
-    md5: c303e2ddfc697a70a137940f8a6b2e1d
-    sha256: 312656da4f0b4b0aacee5914735fdc781bc8412edee6cc90b937a279975d8b1e
-  build: py312h7900ff3_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 76016
   timestamp: 1699923914435
-- platform: win-64
-  name: keyring
-  version: 24.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - jaraco.classes
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - pywin32-ctypes >=0.2.0
-  url: https://conda.anaconda.org/conda-forge/win-64/keyring-24.3.0-py312h2e8e312_0.conda
-  hash:
-    md5: b2ad5f984537e2705416e9de60e9bf52
-    sha256: 2d8d39105c1ad26c2f0b518bc0f35134879231acf9a8717094f50b5cc2d2255a
-  build: py312h2e8e312_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 92690
-  timestamp: 1699924378187
-- platform: linux-64
+- kind: conda
   name: keyutils
   version: 1.6.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-  hash:
-    md5: 30186d27e2c9fa62b45fb1476b7200e3
-    sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+  sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
+  md5: 30186d27e2c9fa62b45fb1476b7200e3
+  depends:
+  - libgcc-ng >=10.3.0
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
-- platform: linux-64
+- kind: conda
   name: krb5
   version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h659d440_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+  sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
+  md5: cd95826dbd331ed1be26bdf401432844
+  depends:
   - keyutils >=1.6.1,<2.0a0
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - openssl >=3.1.2,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
-  hash:
-    md5: cd95826dbd331ed1be26bdf401432844
-    sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  build: h659d440_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 1371181
   timestamp: 1692097755782
-- platform: win-64
+- kind: conda
   name: krb5
   version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
+  build: heb0366b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
+  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  depends:
   - openssl >=3.1.2,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
-  hash:
-    md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
-    sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
-  build: heb0366b_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
   size: 710894
   timestamp: 1692098129546
-- platform: linux-64
+- kind: conda
   name: ld_impl_linux-64
   version: '2.40'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  hash:
-    md5: 7aca3059a1729aa76c597603f10b0dd3
-    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
   build: h41732ed_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
   constrains:
   - binutils_impl_linux-64 2.40
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 704696
   timestamp: 1674833944779
-- platform: linux-64
+- kind: conda
   name: libaec
   version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+  sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
+  md5: 127b0be54c1c90760d7fe02ea7a56426
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
-  hash:
-    md5: 127b0be54c1c90760d7fe02ea7a56426
-    sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
-  build: h59595ed_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 35228
   timestamp: 1696474021700
-- platform: win-64
+- kind: conda
   name: libaec
   version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h63175ca_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+  sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
+  md5: 0b252d2bf460364bccb1523bcdbe4af6
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
-  hash:
-    md5: 0b252d2bf460364bccb1523bcdbe4af6
-    sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
-  build: h63175ca_1
   arch: x86_64
-  subdir: win-64
-  build_number: 1
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
   size: 33554
   timestamp: 1696474526588
-- platform: linux-64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
+  build: 20_linux64_openblas
+  build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
+  sha256: 8a0ee1de693a9b3da4a11b95ec81b40dd434bd01fa1f5f38f8268cd2146bf8f0
+  md5: 2b7bb4f7562c8cf334fc2e20c2d28abc
+  depends:
   - libopenblas >=0.3.25,<0.3.26.0a0
   - libopenblas >=0.3.25,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
-  hash:
-    md5: 2b7bb4f7562c8cf334fc2e20c2d28abc
-    sha256: 8a0ee1de693a9b3da4a11b95ec81b40dd434bd01fa1f5f38f8268cd2146bf8f0
-  build: 20_linux64_openblas
-  arch: x86_64
-  subdir: linux-64
-  build_number: 20
   constrains:
   - liblapacke 3.9.0 20_linux64_openblas
   - libcblas 3.9.0 20_linux64_openblas
   - blas * openblas
   - liblapack 3.9.0 20_linux64_openblas
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14433
   timestamp: 1700568383457
-- platform: win-64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - mkl 2023.2.0 h6a75c08_50497
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-20_win64_mkl.conda
-  hash:
-    md5: 6cad6cd2fbdeef4d651b8f752a4da960
-    sha256: 34becfe991510be7b9ee05b4ae466c5a26a72af275c3071c1ca7e2308d3f7e64
-  build: 20_win64_mkl
-  arch: x86_64
+  build: 21_win64_openblas
+  build_number: 21
   subdir: win-64
-  build_number: 20
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_openblas.conda
+  sha256: f3efad3b893086c8883c6e00f58d9687eace24e1e780ed39967680f434bad2da
+  md5: 62ce74acc92bdb5824c6a86a096709de
+  depends:
+  - libopenblas 0.3.26 pthreads_hc140b1d_0
   constrains:
-  - liblapacke 3.9.0 20_win64_mkl
-  - blas * mkl
-  - liblapack 3.9.0 20_win64_mkl
-  - libcblas 3.9.0 20_win64_mkl
+  - liblapack 3.9.0 21_win64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
+  track_features:
+  - blas_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 4981090
-  timestamp: 1700569135332
-- platform: linux-64
+  size: 3973197
+  timestamp: 1705979993813
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
-  hash:
-    md5: 36d486d72ab64ffea932329a1d3729a3
-    sha256: 0e34fb0f82262f02fcb279ab4a1db8d50875dc98e3019452f8f387e6bf3c0247
   build: 20_linux64_openblas
-  arch: x86_64
-  subdir: linux-64
   build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
+  sha256: 0e34fb0f82262f02fcb279ab4a1db8d50875dc98e3019452f8f387e6bf3c0247
+  md5: 36d486d72ab64ffea932329a1d3729a3
+  depends:
+  - libblas 3.9.0 20_linux64_openblas
   constrains:
   - liblapacke 3.9.0 20_linux64_openblas
   - blas * openblas
   - liblapack 3.9.0 20_linux64_openblas
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14383
   timestamp: 1700568410580
-- platform: win-64
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-20_win64_mkl.conda
-  hash:
-    md5: e6d36cfcb2f2dff0f659d2aa0813eb2d
-    sha256: e526023ed8e7f6fde43698cd326dd16c8448f29414bab8a9594b33deb57a5347
-  build: 20_win64_mkl
-  arch: x86_64
+  build: 21_win64_openblas
+  build_number: 21
   subdir: win-64
-  build_number: 20
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_openblas.conda
+  sha256: e44786130a4feea9557c180c42235ddc87b68616215b1e17145d98db7b6a5aa9
+  md5: bd3b35e4825f64dbf9f2c14b7e5f3624
+  depends:
+  - libblas 3.9.0 21_win64_openblas
   constrains:
-  - blas * mkl
-  - liblapack 3.9.0 20_win64_mkl
-  - liblapacke 3.9.0 20_win64_mkl
+  - blas * openblas
+  - liblapack 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
+  track_features:
+  - blas_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 4980937
-  timestamp: 1700569208640
-- platform: linux-64
+  size: 3973158
+  timestamp: 1705980029383
+- kind: conda
   name: libcurl
   version: 8.4.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hca28451_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.4.0-hca28451_0.conda
+  sha256: 25f4b6a8827d7b17a66e0bd9b5d194bf9a9e4a46fb14e2ef472fdad4b39426a6
+  md5: 1158ac1d2613b28685644931f11ee807
+  depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
   - libnghttp2 >=1.52.0,<2.0a0
@@ -1984,229 +1479,207 @@ package:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.3,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.4.0-hca28451_0.conda
-  hash:
-    md5: 1158ac1d2613b28685644931f11ee807
-    sha256: 25f4b6a8827d7b17a66e0bd9b5d194bf9a9e4a46fb14e2ef472fdad4b39426a6
-  build: hca28451_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: curl
   license_family: MIT
   size: 386160
   timestamp: 1697009208544
-- platform: win-64
+- kind: conda
   name: libcurl
   version: 8.4.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hd5e4a3a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
+  sha256: f1367d8a3f115ee4c16ea4bcc313c21009decb0217f65d3bb94618939c518a71
+  md5: 13e4e3824a0212103330f57058601c21
+  depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libssh2 >=1.11.0,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
-  hash:
-    md5: 13e4e3824a0212103330f57058601c21
-    sha256: f1367d8a3f115ee4c16ea4bcc313c21009decb0217f65d3bb94618939c518a71
-  build: hd5e4a3a_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: curl
   license_family: MIT
   size: 321118
   timestamp: 1697009866852
-- platform: linux-64
+- kind: conda
   name: libedit
   version: 3.1.20191231
-  category: main
-  manager: conda
-  dependencies:
+  build: he28a2e2_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+  sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+  md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+  depends:
   - libgcc-ng >=7.5.0
   - ncurses >=6.2,<7.0.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-  hash:
-    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  build: he28a2e2_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 123878
   timestamp: 1597616541093
-- platform: linux-64
+- kind: conda
   name: libev
   version: '4.33'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
-  hash:
-    md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
-    sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
   build: h516909a_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+  sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
+  md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
+  depends:
+  - libgcc-ng >=7.5.0
+  arch: x86_64
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 106190
   timestamp: 1598867915
-- platform: linux-64
+- kind: conda
   name: libexpat
   version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 6305a3dd2752c76335295da4e581f2fd
-    sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
   build: hcb278e6_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
+  md5: 6305a3dd2752c76335295da4e581f2fd
+  depends:
+  - libgcc-ng >=12
   constrains:
   - expat 2.5.0.*
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   size: 77980
   timestamp: 1680190528313
-- platform: win-64
-  name: libexpat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
-  hash:
-    md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
-    sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
-  build: h63175ca_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 138689
-  timestamp: 1680190844101
-- platform: linux-64
+- kind: conda
   name: libffi
   version: 3.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
-  hash:
-    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
-    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   build: h7f98852_5
-  arch: x86_64
-  subdir: linux-64
   build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   size: 58292
   timestamp: 1636488182923
-- platform: win-64
+- kind: conda
   name: libffi
   version: 3.4.2
-  category: main
-  manager: conda
-  dependencies:
+  build: h8ffe710_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-  hash:
-    md5: 2c96d1b6915b408893f9472569dee135
-    sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
-  build: h8ffe710_5
   arch: x86_64
-  subdir: win-64
-  build_number: 5
+  platform: win
   license: MIT
   license_family: MIT
   size: 42063
   timestamp: 1636489106777
-- platform: linux-64
+- kind: conda
+  name: libflang
+  version: 5.0.0
+  build: h6538335_20180525
+  build_number: 20180525
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+  sha256: 0b893b511190332320f4a3e3d6424fbd350271ffbca34eb25b5cd8bc451f1a05
+  md5: 9f473a344e18668e99a93f7e21a54b69
+  depends:
+  - openmp 5.0.0
+  - vc >=14,<15.0a0
+  arch: x86_64
+  platform: win
+  track_features:
+  - flang
+  license: Apache 2.0
+  size: 531143
+  timestamp: 1527899216421
+- kind: conda
   name: libgcc-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h807b86a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+  sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
+  md5: 23fdf1fef05baeb7eadc2aed5fb0011f
+  depends:
   - _libgcc_mutex 0.1 conda_forge
   - _openmp_mutex >=4.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
-  hash:
-    md5: 23fdf1fef05baeb7eadc2aed5fb0011f
-    sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
-  build: h807b86a_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   constrains:
   - libgomp 13.2.0 h807b86a_3
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 773629
   timestamp: 1699753612541
-- platform: linux-64
+- kind: conda
   name: libgfortran-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgfortran5 13.2.0 ha4646dd_3
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
-  hash:
-    md5: 73031c79546ad06f1fe62e57fdd021bc
-    sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
   build: h69a702a_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
+  sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
+  md5: 73031c79546ad06f1fe62e57fdd021bc
+  depends:
+  - libgfortran5 13.2.0 ha4646dd_3
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 23837
   timestamp: 1699753845201
-- platform: linux-64
+- kind: conda
   name: libgfortran5
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
-  hash:
-    md5: c714d905cdfa0e70200f68b80cc04764
-    sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
   build: ha4646dd_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
+  sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
+  md5: c714d905cdfa0e70200f68b80cc04764
+  depends:
+  - libgcc-ng >=13.2.0
   constrains:
   - libgfortran-ng 13.2.0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 1436929
   timestamp: 1699753630186
-- platform: linux-64
+- kind: conda
   name: libglib
   version: 2.78.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h783c2da_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.1-h783c2da_1.conda
+  sha256: 4e6fa28002f834cfc30a64792e95c1701d835cc3d3a4bb18d6e8d16bb8aba05b
+  md5: 70052d6c1e84643e30ffefb21ab6950f
+  depends:
   - gettext >=0.21.1,<1.0a0
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
@@ -2214,694 +1687,502 @@ package:
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - pcre2 >=10.42,<10.43.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.1-h783c2da_1.conda
-  hash:
-    md5: 70052d6c1e84643e30ffefb21ab6950f
-    sha256: 4e6fa28002f834cfc30a64792e95c1701d835cc3d3a4bb18d6e8d16bb8aba05b
-  build: h783c2da_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   constrains:
   - glib 2.78.1 *_1
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later
   size: 2689247
   timestamp: 1700083047524
-- platform: linux-64
+- kind: conda
   name: libgomp
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - _libgcc_mutex 0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_3.conda
-  hash:
-    md5: 7124cbb46b13d395bdde68f2d215c989
-    sha256: 6ebedee39b6bbbc969715d0d7fa4b381cce67e1139862604ffa393f821c08e81
   build: h807b86a_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_3.conda
+  sha256: 6ebedee39b6bbbc969715d0d7fa4b381cce67e1139862604ffa393f821c08e81
+  md5: 7124cbb46b13d395bdde68f2d215c989
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 421834
   timestamp: 1699753531479
-- platform: win-64
-  name: libhwloc
-  version: 2.9.3
-  category: main
-  manager: conda
-  dependencies:
-  - libxml2 >=2.11.5,<2.12.0a0
-  - pthreads-win32
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
-  hash:
-    md5: 87da045f6d26ce9fe20ad76a18f6a18a
-    sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
-  build: default_haede6df_1009
-  arch: x86_64
-  subdir: win-64
-  build_number: 1009
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2578462
-  timestamp: 1694533393675
-- platform: linux-64
+- kind: conda
   name: libiconv
   version: '1.17'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
-  hash:
-    md5: b62b52da46c39ee2bc3c162ac7f1804d
-    sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+  sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
+  md5: b62b52da46c39ee2bc3c162ac7f1804d
+  depends:
+  - libgcc-ng >=10.3.0
+  arch: x86_64
+  platform: linux
   license: GPL and LGPL
   size: 1450368
   timestamp: 1652700749886
-- platform: win-64
-  name: libiconv
-  version: '1.17'
-  category: main
-  manager: conda
-  dependencies:
-  - vc >=14.1,<15
-  - vs2015_runtime >=14.16.27033
-  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
-  hash:
-    md5: 050119977a86e4856f0416e2edcf81bb
-    sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
-  build: h8ffe710_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: GPL and LGPL
-  size: 714518
-  timestamp: 1652702326553
-- platform: linux-64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
-  hash:
-    md5: 6fabc51f5e647d09cc010c40061557e0
-    sha256: ad7745b8d0f2ccb9c3ba7aaa7167d62fc9f02e45eb67172ae5f0dfb5a3b1a2cc
   build: 20_linux64_openblas
-  arch: x86_64
-  subdir: linux-64
   build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
+  sha256: ad7745b8d0f2ccb9c3ba7aaa7167d62fc9f02e45eb67172ae5f0dfb5a3b1a2cc
+  md5: 6fabc51f5e647d09cc010c40061557e0
+  depends:
+  - libblas 3.9.0 20_linux64_openblas
   constrains:
   - liblapacke 3.9.0 20_linux64_openblas
   - libcblas 3.9.0 20_linux64_openblas
   - blas * openblas
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14350
   timestamp: 1700568424034
-- platform: win-64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-20_win64_mkl.conda
-  hash:
-    md5: 9510d07424d70fcac553d86b3e4a7c14
-    sha256: 7627ef580c26e48c3496b5885fd32be4e4db49fa1077eb21235dc638489565f6
-  build: 20_win64_mkl
-  arch: x86_64
+  build: 21_win64_openblas
+  build_number: 21
   subdir: win-64
-  build_number: 20
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_openblas.conda
+  sha256: 9a00ab203a34ebf46e5963a653e5fc8baf14b13a0fd2090140032395df852ffe
+  md5: 505d2b51f16f4c309a110bc665c157a6
+  depends:
+  - libblas 3.9.0 21_win64_openblas
   constrains:
-  - liblapacke 3.9.0 20_win64_mkl
-  - blas * mkl
-  - libcblas 3.9.0 20_win64_mkl
+  - blas * openblas
+  - libcblas 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
+  track_features:
+  - blas_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 4980967
-  timestamp: 1700569262298
-- platform: linux-64
+  size: 3973581
+  timestamp: 1705980063912
+- kind: conda
   name: libnghttp2
   version: 1.58.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h47da74e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_0.conda
+  sha256: 151b18e4f92dcca263a6d23e4beb0c4e2287aa1c7d0587ff71ef50035ed34aca
+  md5: 9b13d5ee90fc9f09d54fd403247342b4
+  depends:
   - c-ares >=1.21.0,<2.0a0
   - libev >=4.33,<4.34.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_0.conda
-  hash:
-    md5: 9b13d5ee90fc9f09d54fd403247342b4
-    sha256: 151b18e4f92dcca263a6d23e4beb0c4e2287aa1c7d0587ff71ef50035ed34aca
-  build: h47da74e_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 631397
   timestamp: 1699440427647
-- platform: linux-64
+- kind: conda
   name: libnsl
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  hash:
-    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
-    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- platform: linux-64
+- kind: conda
   name: libopenblas
   version: 0.3.25
-  category: main
-  manager: conda
-  dependencies:
+  build: pthreads_h413a1c8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
+  sha256: 628564517895ee1b09cf72c817548bd80ef1acce6a8214a8520d9f7b44c4cfaf
+  md5: d172b34a443b95f86089e8229ddc9a17
+  depends:
   - libgcc-ng >=12
   - libgfortran-ng
   - libgfortran5 >=12.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
-  hash:
-    md5: d172b34a443b95f86089e8229ddc9a17
-    sha256: 628564517895ee1b09cf72c817548bd80ef1acce6a8214a8520d9f7b44c4cfaf
-  build: pthreads_h413a1c8_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - openblas >=0.3.25,<0.3.26.0a0
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 5545169
   timestamp: 1700536004164
-- platform: linux-64
-  name: libsqlite
-  version: 3.44.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
-  hash:
-    md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
-    sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
-  build: h2797004_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Unlicense
-  size: 845830
-  timestamp: 1700863204572
-- platform: win-64
-  name: libsqlite
-  version: 3.44.2
-  category: main
-  manager: conda
-  dependencies:
+- kind: conda
+  name: libopenblas
+  version: 0.3.26
+  build: pthreads_hc140b1d_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.26-pthreads_hc140b1d_0.conda
+  sha256: 40443fa1fa6015ca64f50ea75407ffe3c5d951b6879fc8a345d13603766ef845
+  md5: 961a6872e97cdeba131645e987179443
+  depends:
+  - libflang >=5.0.0,<6.0.0.a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.2-hcfcfb64_0.conda
-  hash:
-    md5: 4a5f5ab56cbf3ccd08d71a1168061213
-    sha256: 25bfcf79ec863c2c0f0b3599981e2eac57efc5302faf2bb84f68c3f0faa55d1c
-  build: hcfcfb64_0
+  constrains:
+  - openblas >=0.3.26,<0.3.27.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3970611
+  timestamp: 1704955151478
+- kind: conda
+  name: libsqlite
+  version: 3.44.2
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
+  sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
+  md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   arch: x86_64
+  platform: linux
+  license: Unlicense
+  size: 845830
+  timestamp: 1700863204572
+- kind: conda
+  name: libsqlite
+  version: 3.44.2
+  build: hcfcfb64_0
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.2-hcfcfb64_0.conda
+  sha256: 25bfcf79ec863c2c0f0b3599981e2eac57efc5302faf2bb84f68c3f0faa55d1c
+  md5: 4a5f5ab56cbf3ccd08d71a1168061213
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  arch: x86_64
+  platform: win
   license: Unlicense
   size: 853171
   timestamp: 1700863704859
-- platform: linux-64
+- kind: conda
   name: libssh2
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h0841786_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-  hash:
-    md5: 1f5a58e686b13bcfde88b93f547d23fe
-    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
-  build: h0841786_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 271133
   timestamp: 1685837707056
-- platform: win-64
+- kind: conda
   name: libssh2
   version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h7dfc565_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
-  hash:
-    md5: dc262d03aae04fe26825062879141a41
-    sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
-  build: h7dfc565_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 266806
   timestamp: 1685838242099
-- platform: linux-64
+- kind: conda
   name: libstdcxx-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
-  hash:
-    md5: 937eaed008f6bf2191c5fe76f87755e9
-    sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
   build: h7e041cc_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
+  sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
+  md5: 937eaed008f6bf2191c5fe76f87755e9
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 3842940
   timestamp: 1699753676253
-- platform: linux-64
+- kind: conda
   name: libuuid
   version: 2.38.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  hash:
-    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
-    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   build: h0b41bf4_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- platform: win-64
-  name: libxml2
-  version: 2.11.6
-  category: main
-  manager: conda
-  dependencies:
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.6-hc3477c8_0.conda
-  hash:
-    md5: 08ffbb4c22dd3622e122058368f8b708
-    sha256: 6ed853ef69bf43998eacc6fd022d7ac170d9e2d3d273b0be0dc3da593fb0fc90
-  build: hc3477c8_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 1627582
-  timestamp: 1700245325646
-- platform: linux-64
+- kind: conda
   name: libzlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: f36c115f1ee199da648e0597ec2047ad
-    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  size: 61588
-  timestamp: 1686575217516
-- platform: win-64
-  name: libzlib
-  version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
-  hash:
-    md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
-    sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
   build: hcfcfb64_5
-  arch: x86_64
-  subdir: win-64
   build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   constrains:
   - zlib 1.2.13 *_5
+  arch: x86_64
+  platform: win
   license: Zlib
   license_family: Other
   size: 55800
   timestamp: 1686575452215
-- platform: linux-64
-  name: markdown-it-py
-  version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - mdurl >=0.1,<1
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: hd590300_5
+  build_number: 5
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 64356
-  timestamp: 1686175179621
-- platform: win-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
+  arch: x86_64
+  platform: linux
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- kind: conda
+  name: llvm-meta
+  version: 5.0.0
+  build: '0'
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+  sha256: 090bbeacc3297ff579b53f55ad184f05c30e316fe9d5d7df63df1d2ad4578b79
+  md5: 213b5b5ad34008147a824460e50a691c
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2667
+- kind: conda
   name: markdown-it-py
   version: 3.0.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
+  sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
+  md5: 93a8e71256479c62074356ef6ebf501b
+  depends:
   - mdurl >=0.1,<1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 93a8e71256479c62074356ef6ebf501b
-    sha256: c041b0eaf7a6af3344d5dd452815cdc148d6284fec25a4fa3f4263b3a021e962
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 64356
   timestamp: 1686175179621
-- platform: linux-64
+- kind: conda
   name: markupsafe
   version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
+  build: py312h98912ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py312h98912ed_1.conda
+  sha256: 2da8fc396399cd3dec8e1464d6b592adca0498e353dc3cdfac34f7eb563956c9
+  md5: 79d118a8f1da01773dd5b334af5ce8d4
+  depends:
   - libgcc-ng >=12
   - python >=3.12.0rc3,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py312h98912ed_1.conda
-  hash:
-    md5: 79d118a8f1da01773dd5b334af5ce8d4
-    sha256: 2da8fc396399cd3dec8e1464d6b592adca0498e353dc3cdfac34f7eb563956c9
-  build: py312h98912ed_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   constrains:
   - jinja2 >=3.0.0
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 26655
   timestamp: 1695367675021
-- platform: win-64
+- kind: conda
   name: markupsafe
-  version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  version: 2.1.5
+  build: py311ha68e1ae_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.5-py311ha68e1ae_0.conda
+  sha256: c629f79fe78b5df7f08daa6b7f125f7a67f789bf734949c6d68aa063d7296208
+  md5: 07da1326e2837e055ef6f44ef3334b0a
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py312he70551f_1.conda
-  hash:
-    md5: 1615e2aa0daf737f06e0d1a3b39d74a8
-    sha256: 013cc2303b0bdfc4c3f43a363b8a208ce3971c727ebd870198db5c6c1f36c7c0
-  build: py312he70551f_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 28973
-  timestamp: 1695367885602
-- platform: linux-64
+  size: 30011
+  timestamp: 1706900632904
+- kind: conda
   name: matplotlib-inline
   version: 0.1.6
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+  sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+  md5: b21613793fcc81d944c76c9f2864a7de
+  depends:
   - python >=3.6
   - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 12273
   timestamp: 1660814913405
-- platform: win-64
-  name: matplotlib-inline
-  version: 0.1.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 12273
-  timestamp: 1660814913405
-- platform: linux-64
+- kind: conda
   name: mdurl
   version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f8dab71fdc13b1bf29a01248b156d268
-    sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
+  md5: f8dab71fdc13b1bf29a01248b156d268
+  depends:
+  - python >=3.6
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 13707
   timestamp: 1639515992326
-- platform: win-64
-  name: mdurl
-  version: 0.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f8dab71fdc13b1bf29a01248b156d268
-    sha256: c678b9194e025b1fb665bec30ee20aab93399203583875b1dcc0a3b52a8f5523
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 13707
-  timestamp: 1639515992326
-- platform: win-64
-  name: mkl
-  version: 2023.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - intel-openmp 2023.*
-  - tbb 2021.*
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50497.conda
-  hash:
-    md5: 064cea9f45531e7b53584acf4bd8b044
-    sha256: 46ec9e767279da219398b6e79c8fa95822b2ed3c8e02ab604615b7d1213a5d5a
-  build: h6a75c08_50497
-  arch: x86_64
-  subdir: win-64
-  build_number: 50497
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 144666110
-  timestamp: 1698352013664
-- platform: linux-64
+- kind: conda
   name: more-itertools
   version: 10.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
-    sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 53654
-  timestamp: 1691087125209
-- platform: win-64
-  name: more-itertools
-  version: 10.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
-    sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.1.0-pyhd8ed1ab_0.conda
+  sha256: 07ce65497dec537e490992758934ddbc4fb5ed9285b41387a7cca966f1a98a0f
+  md5: 8549fafed0351bbfaa1ddaa15fdf9b4e
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 53654
   timestamp: 1691087125209
-- platform: linux-64
+- kind: conda
   name: ncurses
   version: '6.4'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
-  hash:
-    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
-    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
   build: h59595ed_2
-  arch: x86_64
-  subdir: linux-64
   build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: X11 AND BSD-3-Clause
   size: 884434
   timestamp: 1698751260967
-- platform: linux-64
+- kind: conda
   name: nh3
   version: 0.2.14
-  category: main
-  manager: conda
-  dependencies:
+  build: py312h4b3b743_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.14-py312h4b3b743_1.conda
+  sha256: 056579eeca71e809549f9b6786b71385ae71d9150e3a3caf35eb9a829ee366d0
+  md5: 41bf8d6d36ad4d33b6f8cf741648cddd
+  depends:
   - libgcc-ng >=12
   - python >=3.12.0rc3,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.14-py312h4b3b743_1.conda
-  hash:
-    md5: 41bf8d6d36ad4d33b6f8cf741648cddd
-    sha256: 056579eeca71e809549f9b6786b71385ae71d9150e3a3caf35eb9a829ee366d0
-  build: py312h4b3b743_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: MIT
   license_family: MIT
   size: 621567
   timestamp: 1695423328803
-- platform: win-64
+- kind: conda
   name: nh3
-  version: 0.2.14
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.14-py312h426fad5_1.conda
-  hash:
-    md5: 27029a8cd7698df4bd7a171a156c5f7a
-    sha256: 404739aab4d8250da13b9d59da288ac4d5843c2a9cd7976b0cd4ef8bd9be42b2
-  build: py312h426fad5_1
-  arch: x86_64
+  version: 0.2.15
+  build: py311h633b200_0
   subdir: win-64
-  build_number: 1
+  url: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.15-py311h633b200_0.conda
+  sha256: d0b5ed5621d01adc223971f83b00e2d3cdab870b5913322cec3d5ed4ada0aef2
+  md5: c3f2f171c4a730eec6c0534f0227cafe
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  size: 500452
-  timestamp: 1695424134011
-- platform: linux-64
+  size: 493281
+  timestamp: 1701975459413
+- kind: conda
+  name: nomkl
+  version: '1.0'
+  build: h5ca1d4c_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+  sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+  md5: 9a66894dfd07c4510beb6b3f9672ccc0
+  constrains:
+  - mkl <0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3843
+  timestamp: 1582593857545
+- kind: conda
   name: numpy
   version: 1.26.2
-  category: main
-  manager: conda
-  dependencies:
+  build: py312heda63a1_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.2-py312heda63a1_0.conda
+  sha256: d7fde9d38f4c9e41503a0f5e20a2d53918c52cb7e60ae3814ff8a4e59c2b39f8
+  md5: 6d7b0ae4472449b7893345c015f486d3
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
@@ -2909,140 +2190,120 @@ package:
   - libstdcxx-ng >=12
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.2-py312heda63a1_0.conda
-  hash:
-    md5: 6d7b0ae4472449b7893345c015f486d3
-    sha256: d7fde9d38f4c9e41503a0f5e20a2d53918c52cb7e60ae3814ff8a4e59c2b39f8
-  build: py312heda63a1_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - numpy-base <0a0
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 7598150
   timestamp: 1700874851101
-- platform: win-64
+- kind: conda
   name: numpy
-  version: 1.26.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.26.4
+  build: py311h0b4df5a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+  sha256: 14116e72107de3089cc58119a5ce5905c22abf9a715c9fe41f8ac14db0992326
+  md5: 7b240edd44fd7a0991aa409b07cee776
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.2-py312h8753938_0.conda
-  hash:
-    md5: d02be9e6d2465d2161a091c8adaf8446
-    sha256: e3a274eec986bd606630a86b63519773939a2def83fac85983ecd5a71b2bac85
-  build: py312h8753938_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
-  license_family: BSD
-  size: 6393785
-  timestamp: 1700875379700
-- platform: linux-64
-  name: openssl
-  version: 3.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - ca-certificates
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
-  hash:
-    md5: 603827b39ea2b835268adb8c821b8570
-    sha256: 80efc6f429bd8e622d999652e5cba2ca56fcdb9c16a439d2ce9b4313116e4a87
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
+  size: 7104093
+  timestamp: 1707226459646
+- kind: conda
+  name: openmp
+  version: 5.0.0
+  build: vc14_1
   build_number: 1
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2854103
-  timestamp: 1701162437033
-- platform: win-64
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+  sha256: 05c19170938b589f59049679d4e0679c98160fecc6fd1bf721b0f4980bd235dd
+  md5: 8284c925330fa53668ade00db3c9e787
+  depends:
+  - llvm-meta 5.0.0|5.0.0.*
+  - vc 14.*
+  arch: x86_64
+  platform: win
+  license: NCSA
+  size: 590466
+- kind: conda
   name: openssl
   version: 3.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hcfcfb64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.0-hcfcfb64_1.conda
+  sha256: 373b9671173ef3413d2a95f3781176b818db904ba82298f8447b9658d71e2cc9
+  md5: d10167022f99bad12ee07dea022d5830
+  depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.0-hcfcfb64_1.conda
-  hash:
-    md5: d10167022f99bad12ee07dea022d5830
-    sha256: 373b9671173ef3413d2a95f3781176b818db904ba82298f8447b9658d71e2cc9
-  build: hcfcfb64_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
   constrains:
   - pyopenssl >=22.1
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 8248125
   timestamp: 1701164404616
-- platform: linux-64
-  name: packaging
-  version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: openssl
+  version: 3.2.0
+  build: hd590300_1
+  build_number: 1
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
+  sha256: 80efc6f429bd8e622d999652e5cba2ca56fcdb9c16a439d2ce9b4313116e4a87
+  md5: 603827b39ea2b835268adb8c821b8570
+  depends:
+  - ca-certificates
+  - libgcc-ng >=12
+  constrains:
+  - pyopenssl >=22.1
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 49452
-  timestamp: 1696202521121
-- platform: win-64
+  license_family: Apache
+  size: 2854103
+  timestamp: 1701162437033
+- kind: conda
   name: packaging
   version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 49452
   timestamp: 1696202521121
-- platform: linux-64
+- kind: conda
   name: pandas
   version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
+  build: py312hfb8ada1_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.3-py312hfb8ada1_0.conda
+  sha256: 9dbdcf22a8e85b5c1794e3ccba46c3c8d18a3e985da05a84387fe8f98f4a0124
+  md5: ef74af58f348d62a35c58e82aef5f868
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - numpy >=1.26.0,<2.0a0
@@ -3051,668 +2312,349 @@ package:
   - python-tzdata >=2022a
   - python_abi 3.12.* *_cp312
   - pytz >=2020.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.3-py312hfb8ada1_0.conda
-  hash:
-    md5: ef74af58f348d62a35c58e82aef5f868
-    sha256: 9dbdcf22a8e85b5c1794e3ccba46c3c8d18a3e985da05a84387fe8f98f4a0124
-  build: py312hfb8ada1_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14692219
   timestamp: 1699670548374
-- platform: win-64
+- kind: conda
   name: pandas
-  version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - numpy >=1.26.0,<2.0a0
-  - python >=3.12,<3.13.0a0
+  version: 2.2.0
+  build: py311hf63dbb6_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.0-py311hf63dbb6_0.conda
+  sha256: 20dbb4f8013b39b6f62350b1e82e3c97a00573f6d54e86152c8e27fda69f3a32
+  md5: 19e55b3676a5f783c44d864fbb29ef41
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
   - python-dateutil >=2.8.1
   - python-tzdata >=2022a
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.11.* *_cp311
   - pytz >=2020.1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.1.3-py312h2ab9e98_0.conda
-  hash:
-    md5: 9719f7ff92b362df61e8e6abf5886742
-    sha256: a4207972ce906f6647c48fca868116cc243c87a391307544e3a270c7edb7f317
-  build: py312h2ab9e98_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 13538431
-  timestamp: 1699670949801
-- platform: linux-64
+  size: 14570059
+  timestamp: 1705729588827
+- kind: conda
   name: parso
   version: 0.8.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 71048
-  timestamp: 1638335054552
-- platform: win-64
-  name: parso
-  version: 0.8.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
+  sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+  md5: 17a565a0c3899244e938cdf417e7b094
+  depends:
+  - python >=3.6
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 71048
   timestamp: 1638335054552
-- platform: linux-64
+- kind: conda
   name: pcre2
   version: '10.42'
-  category: main
-  manager: conda
-  dependencies:
+  build: hcad00b1_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
+  sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
+  md5: 679c8961826aa4b50653bce17ee52abe
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
-  hash:
-    md5: 679c8961826aa4b50653bce17ee52abe
-    sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
-  build: hcad00b1_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 1017235
   timestamp: 1698610864983
-- platform: linux-64
+- kind: conda
   name: pep517
   version: 0.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  - tomli
-  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d94aa03d99d8adc9898f783eba0d84d2
-    sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 19044
-  timestamp: 1667916747996
-- platform: win-64
-  name: pep517
-  version: 0.13.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  - tomli
-  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d94aa03d99d8adc9898f783eba0d84d2
-    sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
+  md5: d94aa03d99d8adc9898f783eba0d84d2
+  depends:
+  - python >=3.8
+  - tomli
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 19044
   timestamp: 1667916747996
-- platform: linux-64
+- kind: conda
   name: pexpect
   version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyh1a96a4e_2
+  build_number: 2
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
+  sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+  md5: 330448ce4403cc74990ac07c555942a1
+  depends:
   - ptyprocess >=0.5
   - python
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
-  hash:
-    md5: 330448ce4403cc74990ac07c555942a1
-    sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
-  build: pyh1a96a4e_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: ISC
-  noarch: python
   size: 48780
   timestamp: 1667297617062
-- platform: linux-64
+- kind: conda
   name: pickleshare
   version: 0.7.5
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
   build: py_1003
-  arch: x86_64
-  subdir: linux-64
   build_number: 1003
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 9332
-  timestamp: 1602536313357
-- platform: win-64
-  name: pickleshare
-  version: 0.7.5
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-  build: py_1003
-  arch: x86_64
   subdir: win-64
-  build_number: 1003
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
+  sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+  md5: 415f0ebb6198cc2801c73438a9fb5761
+  depends:
+  - python >=3
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 9332
   timestamp: 1602536313357
-- platform: linux-64
+- kind: conda
   name: pip
   version: 23.3.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
+  sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
+  md5: 2400c0b86889f43aa52067161e1fb108
+  depends:
   - python >=3.7
   - setuptools
   - wheel
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2400c0b86889f43aa52067161e1fb108
-    sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 1398838
   timestamp: 1697896918388
-- platform: win-64
-  name: pip
-  version: 23.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - setuptools
-  - wheel
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2400c0b86889f43aa52067161e1fb108
-    sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 1398838
-  timestamp: 1697896918388
-- platform: linux-64
+- kind: conda
   name: pkginfo
   version: 1.9.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.9.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: be1e9f1c65a1ed0f2ae9352fec99db64
-    sha256: 7ea5a5af62a15376d9f4f9f3c134874d0b0710f39be719e849b7fa9ca8870502
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.9.6-pyhd8ed1ab_0.conda
+  sha256: 7ea5a5af62a15376d9f4f9f3c134874d0b0710f39be719e849b7fa9ca8870502
+  md5: be1e9f1c65a1ed0f2ae9352fec99db64
+  depends:
+  - python >=3.6
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 27646
   timestamp: 1673281872032
-- platform: win-64
-  name: pkginfo
-  version: 1.9.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.9.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: be1e9f1c65a1ed0f2ae9352fec99db64
-    sha256: 7ea5a5af62a15376d9f4f9f3c134874d0b0710f39be719e849b7fa9ca8870502
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 27646
-  timestamp: 1673281872032
-- platform: linux-64
+- kind: conda
   name: pluggy
   version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2390bd10bed1f3fdc7a537fb5a447d8d
-    sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
+  sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
+  md5: 2390bd10bed1f3fdc7a537fb5a447d8d
+  depends:
+  - python >=3.8
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 22548
   timestamp: 1693086745921
-- platform: win-64
-  name: pluggy
-  version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2390bd10bed1f3fdc7a537fb5a447d8d
-    sha256: 7bf2ad9d747e71f1e93d0863c2c8061dd0f2fe1e582f28d292abfb40264a2eb5
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 22548
-  timestamp: 1693086745921
-- platform: linux-64
+- kind: conda
   name: prompt-toolkit
   version: 3.0.41
-  category: main
-  manager: conda
-  dependencies:
+  build: pyha770c72_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
+  sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
+  md5: f511a993aa4336bef9dd874ee3403e67
+  depends:
   - python >=3.7
   - wcwidth
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
-  hash:
-    md5: f511a993aa4336bef9dd874ee3403e67
-    sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - prompt_toolkit 3.0.41
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 269969
   timestamp: 1699963207861
-- platform: win-64
-  name: prompt-toolkit
-  version: 3.0.41
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - wcwidth
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
-  hash:
-    md5: f511a993aa4336bef9dd874ee3403e67
-    sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  constrains:
-  - prompt_toolkit 3.0.41
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 269969
-  timestamp: 1699963207861
-- platform: win-64
-  name: pthreads-win32
-  version: 2.9.1
-  category: main
-  manager: conda
-  dependencies:
-  - vc 14.*
-  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
-  hash:
-    md5: e2da8758d7d51ff6aa78a14dfb9dbed4
-    sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
-  build: hfa6e2cd_3
-  arch: x86_64
-  subdir: win-64
-  build_number: 3
-  license: LGPL 2
-  size: 144301
-  timestamp: 1537755684331
-- platform: linux-64
+- kind: conda
   name: ptyprocess
   version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
   build: pyhd3deb0d_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: ISC
   noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
+  sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+  md5: 359eeb6536da0e687af562ed265ec263
+  depends:
+  - python
+  arch: x86_64
+  platform: linux
+  license: ISC
   size: 16546
   timestamp: 1609419417991
-- platform: linux-64
+- kind: conda
   name: pure_eval
   version: 0.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+  md5: 6784285c7e55cb7212efabc79e4c2883
+  depends:
+  - python >=3.5
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 14551
   timestamp: 1642876055775
-- platform: win-64
-  name: pure_eval
-  version: 0.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 14551
-  timestamp: 1642876055775
-- platform: linux-64
+- kind: conda
   name: pycparser
   version: '2.21'
-  category: main
-  manager: conda
-  dependencies:
-  - python ==2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 102747
-  timestamp: 1636257201998
-- platform: win-64
-  name: pycparser
-  version: '2.21'
-  category: main
-  manager: conda
-  dependencies:
-  - python ==2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  md5: 076becd9e05608f8dc72757d5f3a91ff
+  depends:
+  - python ==2.7.*|>=3.4
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 102747
   timestamp: 1636257201998
-- platform: linux-64
+- kind: conda
   name: pydoe
   version: 0.3.8
-  category: main
-  manager: conda
-  dependencies:
+  build: py_1
+  build_number: 1
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pydoe-0.3.8-py_1.tar.bz2
+  sha256: 4616364442c3c0c91188ae8b04d3146f21e8826e55e120835d910844e4dbe38e
+  md5: 6aeffd34a05a050c9b01c86de859c459
+  depends:
   - numpy >=1.8
   - python
   - scipy >=0.13
-  url: https://conda.anaconda.org/conda-forge/noarch/pydoe-0.3.8-py_1.tar.bz2
-  hash:
-    md5: 6aeffd34a05a050c9b01c86de859c459
-    sha256: 4616364442c3c0c91188ae8b04d3146f21e8826e55e120835d910844e4dbe38e
-  build: py_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: win
   license: BSD 3-Clause
-  noarch: python
   size: 13421
   timestamp: 1531166118644
-- platform: win-64
-  name: pydoe
-  version: 0.3.8
-  category: main
-  manager: conda
-  dependencies:
-  - numpy >=1.8
-  - python
-  - scipy >=0.13
-  url: https://conda.anaconda.org/conda-forge/noarch/pydoe-0.3.8-py_1.tar.bz2
-  hash:
-    md5: 6aeffd34a05a050c9b01c86de859c459
-    sha256: 4616364442c3c0c91188ae8b04d3146f21e8826e55e120835d910844e4dbe38e
-  build: py_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  license: BSD 3-Clause
-  noarch: python
-  size: 13421
-  timestamp: 1531166118644
-- platform: linux-64
+- kind: conda
   name: pygments
   version: 2.17.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 140a7f159396547e9799aa98f9f0742e
-    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
+  sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
+  md5: 140a7f159396547e9799aa98f9f0742e
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 860425
   timestamp: 1700608076927
-- platform: win-64
-  name: pygments
-  version: 2.17.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 140a7f159396547e9799aa98f9f0742e
-    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 860425
-  timestamp: 1700608076927
-- platform: linux-64
+- kind: conda
   name: pygments_anyscript
   version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - pygments
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments_anyscript-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d9a6b4281185dae5d1c00be66a09d987
-    sha256: a8c41830ba3df5328129deb7531bc49d7aae7fa25d651bde432bb16f6ce05cc9
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 16639
-  timestamp: 1677078365856
-- platform: win-64
-  name: pygments_anyscript
-  version: 1.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - pygments
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments_anyscript-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d9a6b4281185dae5d1c00be66a09d987
-    sha256: a8c41830ba3df5328129deb7531bc49d7aae7fa25d651bde432bb16f6ce05cc9
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments_anyscript-1.3.0-pyhd8ed1ab_0.conda
+  sha256: a8c41830ba3df5328129deb7531bc49d7aae7fa25d651bde432bb16f6ce05cc9
+  md5: d9a6b4281185dae5d1c00be66a09d987
+  depends:
+  - pygments
+  - python >=3.7
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 16639
   timestamp: 1677078365856
-- platform: linux-64
+- kind: conda
   name: pysocks
   version: 1.7.1
-  category: main
-  manager: conda
-  dependencies:
-  - __unix
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-  hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-  build: pyha2e5f31_6
-  arch: x86_64
-  subdir: linux-64
+  build: pyh0701188_6
   build_number: 6
-  license: BSD-3-Clause
-  license_family: BSD
+  subdir: win-64
   noarch: python
-  size: 18981
-  timestamp: 1661604969727
-- platform: win-64
-  name: pysocks
-  version: 1.7.1
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
   - __win
   - python >=3.8
   - win_inet_pton
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
-  hash:
-    md5: 56cd9fe388baac0e90c7149cfac95b60
-    sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
-  build: pyh0701188_6
   arch: x86_64
-  subdir: win-64
-  build_number: 6
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 19348
   timestamp: 1661605138291
-- platform: linux-64
+- kind: conda
+  name: pysocks
+  version: 1.7.1
+  build: pyha2e5f31_6
+  build_number: 6
+  subdir: linux-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18981
+  timestamp: 1661604969727
+- kind: conda
   name: pytest
   version: 7.4.3
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
+  sha256: 14e948e620ec87d9e62a8d9c21d40084b4805a939cfee322be7d457379dc96a0
+  md5: 5bdca0aca30b0ee62bb84854e027eae0
+  depends:
   - colorama
   - exceptiongroup >=1.0.0rc8
   - iniconfig
@@ -3720,103 +2662,68 @@ package:
   - pluggy >=0.12,<2.0
   - python >=3.7
   - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5bdca0aca30b0ee62bb84854e027eae0
-    sha256: 14e948e620ec87d9e62a8d9c21d40084b4805a939cfee322be7d457379dc96a0
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - pytest-faulthandler >=2
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 244758
-  timestamp: 1698233883003
-- platform: win-64
-  name: pytest
-  version: 7.4.3
-  category: main
-  manager: conda
-  dependencies:
-  - colorama
-  - exceptiongroup >=1.0.0rc8
-  - iniconfig
-  - packaging
-  - pluggy >=0.12,<2.0
-  - python >=3.7
-  - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5bdca0aca30b0ee62bb84854e027eae0
-    sha256: 14e948e620ec87d9e62a8d9c21d40084b4805a939cfee322be7d457379dc96a0
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
-  constrains:
-  - pytest-faulthandler >=2
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 244758
   timestamp: 1698233883003
-- platform: linux-64
+- kind: conda
   name: pytest-xdist
   version: 3.5.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
+  sha256: 8dc1d422e48e5a80eb72e26ed0135bb4843cf508d3b1cb006c3257c8639784d1
+  md5: d5f595da2daead898ca958ac62f0307b
+  depends:
   - execnet >=1.1
   - pytest >=6.2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d5f595da2daead898ca958ac62f0307b
-    sha256: 8dc1d422e48e5a80eb72e26ed0135bb4843cf508d3b1cb006c3257c8639784d1
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - psutil >=3.0
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 36516
   timestamp: 1700593072448
-- platform: win-64
-  name: pytest-xdist
-  version: 3.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - execnet >=1.1
-  - pytest >=6.2.0
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d5f595da2daead898ca958ac62f0307b
-    sha256: 8dc1d422e48e5a80eb72e26ed0135bb4843cf508d3b1cb006c3257c8639784d1
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: python
+  version: 3.11.0
+  build: hcf16a7b_0_cpython
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2
+  sha256: 20d1f1b5dc620b745c325844545fd5c0cdbfdb2385a0e27ef1507399844c8c6d
+  md5: 13ee3577afc291dabd2d9edc59736688
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4.2,<3.5.0a0
+  - libsqlite >=3.39.4,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.0.5,<4.0a0
+  - tk >=8.6.12,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  - xz >=5.2.6,<5.3.0a0
   constrains:
-  - psutil >=3.0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 36516
-  timestamp: 1700593072448
-- platform: linux-64
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 19819816
+  timestamp: 1666678800085
+- kind: conda
   name: python
   version: 3.12.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hab00c5b_0_cpython
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
+  sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
+  md5: 7f97faab5bebcc2580f4f299285323da
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
   - libexpat >=2.5.0,<3.0a0
@@ -3832,486 +2739,239 @@ package:
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-  hash:
-    md5: 7f97faab5bebcc2580f4f299285323da
-    sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
-  build: hab00c5b_0_cpython
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - python_abi 3.12.* *_cp312
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   size: 32123473
   timestamp: 1696324522323
-- platform: win-64
-  name: python
-  version: 3.12.0
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
-  hash:
-    md5: defd5d375853a2caff36a19d2d81a28e
-    sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
-  build: h2628c8c_0_cpython
-  arch: x86_64
+- kind: conda
+  name: python-dateutil
+  version: 2.8.2
+  build: pyhd8ed1ab_0
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+  md5: dd999d1cc9f79e67dbb855c8924c7984
+  depends:
+  - python >=3.6
+  - six >=1.5
+  arch: x86_64
+  platform: win
+  license: Apache-2.0
+  license_family: APACHE
+  size: 245987
+  timestamp: 1626286448716
+- kind: conda
+  name: python-tzdata
+  version: '2023.3'
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
+  sha256: 0108888507014fb24573c31e4deceb61c99e63d37776dddcadd7c89b2ecae0b6
+  md5: 2590495f608a63625e165915fb4e2e34
+  depends:
+  - python >=3.6
+  arch: x86_64
+  platform: win
+  license: Apache-2.0
+  license_family: APACHE
+  size: 143131
+  timestamp: 1680081272948
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 4_cp311
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
+  md5: 70513332c71b56eace4ee6441e66c012
   constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 16140836
-  timestamp: 1696321871976
-- platform: linux-64
-  name: python-dateutil
-  version: 2.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - six >=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 245987
-  timestamp: 1626286448716
-- platform: win-64
-  name: python-dateutil
-  version: 2.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - six >=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 245987
-  timestamp: 1626286448716
-- platform: linux-64
-  name: python-tzdata
-  version: '2023.3'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2590495f608a63625e165915fb4e2e34
-    sha256: 0108888507014fb24573c31e4deceb61c99e63d37776dddcadd7c89b2ecae0b6
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 143131
-  timestamp: 1680081272948
-- platform: win-64
-  name: python-tzdata
-  version: '2023.3'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2590495f608a63625e165915fb4e2e34
-    sha256: 0108888507014fb24573c31e4deceb61c99e63d37776dddcadd7c89b2ecae0b6
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 143131
-  timestamp: 1680081272948
-- platform: linux-64
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6755
+  timestamp: 1695147711935
+- kind: conda
   name: python_abi
   version: '3.12'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
-  hash:
-    md5: dccc2d142812964fcc6abdc97b672dff
-    sha256: 182a329de10a4165f6e8a3804caf751f918f6ea6176dd4e5abcdae1ed3095bf6
   build: 4_cp312
-  arch: x86_64
-  subdir: linux-64
   build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
+  sha256: 182a329de10a4165f6e8a3804caf751f918f6ea6176dd4e5abcdae1ed3095bf6
+  md5: dccc2d142812964fcc6abdc97b672dff
   constrains:
   - python 3.12.* *_cpython
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 6385
   timestamp: 1695147396604
-- platform: win-64
-  name: python_abi
-  version: '3.12'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
-  hash:
-    md5: 17f4ccf6be9ded08bd0a376f489ac1a6
-    sha256: 488f8519d04b48f59bd6fde21ebe2d7a527718ff28aac86a8b53aa63658bdef6
-  build: 4_cp312
-  arch: x86_64
-  subdir: win-64
-  build_number: 4
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6785
-  timestamp: 1695147430513
-- platform: linux-64
+- kind: conda
   name: pytz
   version: 2023.3.post1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c93346b446cd08c169d843ae5fc0da97
-    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 187454
-  timestamp: 1693930444432
-- platform: win-64
-  name: pytz
-  version: 2023.3.post1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c93346b446cd08c169d843ae5fc0da97
-    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+  md5: c93346b446cd08c169d843ae5fc0da97
+  depends:
+  - python >=3.6
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 187454
   timestamp: 1693930444432
-- platform: win-64
+- kind: conda
   name: pywin32-ctypes
   version: 0.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.2-py312h2e8e312_1.conda
-  hash:
-    md5: 93a37178188cd6521e5410763a18aaf4
-    sha256: 238fffa911c4b78fd2153cfd1d0d376326379c98821da4b0cd12a3c6fbf3e9a6
-  build: py312h2e8e312_1
-  arch: x86_64
-  subdir: win-64
+  build: py311h1ea47a8_1
   build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.2-py311h1ea47a8_1.conda
+  sha256: 75a80bda3a87ae9387e8860be7a5271a67846d8929fe8c99799ed40eb085130a
+  md5: e1270294a55b716f9b76900340e8fc82
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  size: 55871
-  timestamp: 1695395307212
-- platform: linux-64
+  size: 57331
+  timestamp: 1695395348158
+- kind: conda
   name: readline
   version: '8.2'
-  category: main
-  manager: conda
-  dependencies:
+  build: h8228510_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-  hash:
-    md5: 47d31b792659ce70f470b5c82fdfb7a4
-    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  build: h8228510_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- platform: linux-64
+- kind: conda
   name: readme_renderer
   version: '42.0'
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-42.0-pyhd8ed1ab_0.conda
+  sha256: 61e03765ebdb168fc8747e8183db4067b55888c89d59e0f4f53b5b4046846cda
+  md5: fdc16f5dc3a911d8f43f64f814a45961
+  depends:
   - cmarkgfm >=0.8.0
   - docutils >=0.13.1
   - nh3 >=0.2.14
   - pygments >=2.5.1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-42.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: fdc16f5dc3a911d8f43f64f814a45961
-    sha256: 61e03765ebdb168fc8747e8183db4067b55888c89d59e0f4f53b5b4046846cda
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 17373
   timestamp: 1694242843889
-- platform: win-64
-  name: readme_renderer
-  version: '42.0'
-  category: main
-  manager: conda
-  dependencies:
-  - cmarkgfm >=0.8.0
-  - docutils >=0.13.1
-  - nh3 >=0.2.14
-  - pygments >=2.5.1
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-42.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: fdc16f5dc3a911d8f43f64f814a45961
-    sha256: 61e03765ebdb168fc8747e8183db4067b55888c89d59e0f4f53b5b4046846cda
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 17373
-  timestamp: 1694242843889
-- platform: linux-64
+- kind: conda
   name: requests
   version: 2.31.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  md5: a30144e4156cdbb236f99ebb49828f8b
+  depends:
   - certifi >=2017.4.17
   - charset-normalizer >=2,<4
   - idna >=2.5,<4
   - python >=3.7
   - urllib3 >=1.21.1,<3
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - chardet >=3.0.2,<6
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 56690
   timestamp: 1684774408600
-- platform: win-64
-  name: requests
-  version: 2.31.0
-  category: main
-  manager: conda
-  dependencies:
-  - certifi >=2017.4.17
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.7
-  - urllib3 >=1.21.1,<3
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  constrains:
-  - chardet >=3.0.2,<6
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 56690
-  timestamp: 1684774408600
-- platform: linux-64
+- kind: conda
   name: requests-toolbelt
   version: 1.0.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda
+  sha256: 20eaefc5dba74ff6c31e537533dde59b5b20f69e74df49dff19d43be59785fa3
+  md5: 99c98318c8646b08cc764f90ce98906e
+  depends:
   - python >=3.6
   - requests >=2.0.1,<3.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 99c98318c8646b08cc764f90ce98906e
-    sha256: 20eaefc5dba74ff6c31e537533dde59b5b20f69e74df49dff19d43be59785fa3
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 43939
   timestamp: 1682953467574
-- platform: win-64
-  name: requests-toolbelt
-  version: 1.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - requests >=2.0.1,<3.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 99c98318c8646b08cc764f90ce98906e
-    sha256: 20eaefc5dba74ff6c31e537533dde59b5b20f69e74df49dff19d43be59785fa3
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 43939
-  timestamp: 1682953467574
-- platform: linux-64
+- kind: conda
   name: rfc3986
   version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d337886e38f965bf97aaec382ff6db00
-    sha256: dd6bfb7c4248ba7612f2e6e4a066d6804ba96dfcaeddf43475a2c846ccfcc396
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 34075
-  timestamp: 1641825125307
-- platform: win-64
-  name: rfc3986
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d337886e38f965bf97aaec382ff6db00
-    sha256: dd6bfb7c4248ba7612f2e6e4a066d6804ba96dfcaeddf43475a2c846ccfcc396
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_0.tar.bz2
+  sha256: dd6bfb7c4248ba7612f2e6e4a066d6804ba96dfcaeddf43475a2c846ccfcc396
+  md5: d337886e38f965bf97aaec382ff6db00
+  depends:
+  - python >=3.4
+  arch: x86_64
+  platform: win
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
   size: 34075
   timestamp: 1641825125307
-- platform: linux-64
+- kind: conda
   name: rich
   version: 13.7.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.0-pyhd8ed1ab_0.conda
+  sha256: 4bb25bf1f5664772b2c4c2e3878aa6e7dc2695f97e3da4ee8e47c51e179913bb
+  md5: d7a11d4f3024b2f4a6e0ae7377dd61e9
+  depends:
   - markdown-it-py >=2.2.0
   - pygments >=2.13.0,<3.0.0
   - python >=3.7.0
   - typing_extensions >=4.0.0,<5.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d7a11d4f3024b2f4a6e0ae7377dd61e9
-    sha256: 4bb25bf1f5664772b2c4c2e3878aa6e7dc2695f97e3da4ee8e47c51e179913bb
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 184071
   timestamp: 1700160247583
-- platform: win-64
-  name: rich
-  version: 13.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.7.0
-  - typing_extensions >=4.0.0,<5.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d7a11d4f3024b2f4a6e0ae7377dd61e9
-    sha256: 4bb25bf1f5664772b2c4c2e3878aa6e7dc2695f97e3da4ee8e47c51e179913bb
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 184071
-  timestamp: 1700160247583
-- platform: linux-64
+- kind: conda
   name: scipy
   version: 1.11.4
-  category: main
-  manager: conda
-  dependencies:
+  build: py312heda63a1_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.4-py312heda63a1_0.conda
+  sha256: b262cccac96998f2de22a7ff0df9d6382e0582f8efc3803c07b45efbd94a3d84
+  md5: e1fac3255958529700de75951f060710
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
@@ -4323,195 +2983,118 @@ package:
   - numpy >=1.26.0,<2.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.4-py312heda63a1_0.conda
-  hash:
-    md5: e1fac3255958529700de75951f060710
-    sha256: b262cccac96998f2de22a7ff0df9d6382e0582f8efc3803c07b45efbd94a3d84
-  build: py312heda63a1_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 15828429
   timestamp: 1700813529973
-- platform: win-64
+- kind: conda
   name: scipy
-  version: 1.11.4
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.12.0
+  build: py311h0b4df5a_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.12.0-py311h0b4df5a_2.conda
+  sha256: 0519e3a4988d56e689a37d2a79b3d5cb15591d4e9428b3a66fdb607310295f1f
+  md5: eeccea26a9e7819b4ab9e69e4d7b9b44
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.26.0,<1.28
-  - numpy >=1.26.0,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - numpy >=1.23.5,<1.28
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.4-py312h8753938_0.conda
-  hash:
-    md5: 9544b9b9db05f8ff06b5565012162fd3
-    sha256: fcb1351ba232151e61e94b18d4ef29ea3d8ab83932407d1c5c5f6f00f3b483e5
-  build: py312h8753938_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 14475110
-  timestamp: 1700814717706
-- platform: linux-64
+  size: 15968999
+  timestamp: 1706043936628
+- kind: conda
   name: secretstorage
   version: 3.3.3
-  category: main
-  manager: conda
-  dependencies:
+  build: py312h7900ff3_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_2.conda
+  sha256: 0479e3f8c8e90049a6d92d4c7e67916c6d6cdafd11a1a31c54c785cce44aeb20
+  md5: 39067833cbb620066d492f8bd6f11dbf
+  depends:
   - cryptography
   - dbus
   - jeepney >=0.6
   - python >=3.12.0rc3,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_2.conda
-  hash:
-    md5: 39067833cbb620066d492f8bd6f11dbf
-    sha256: 0479e3f8c8e90049a6d92d4c7e67916c6d6cdafd11a1a31c54c785cce44aeb20
-  build: py312h7900ff3_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 31766
   timestamp: 1695551875966
-- platform: linux-64
+- kind: conda
   name: setuptools
   version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 464399
   timestamp: 1694548452441
-- platform: win-64
-  name: setuptools
-  version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 464399
-  timestamp: 1694548452441
-- platform: linux-64
+- kind: conda
   name: six
   version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
   build: pyh6c4a22f_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 14259
   timestamp: 1620240338595
-- platform: win-64
-  name: six
-  version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-  build: pyh6c4a22f_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 14259
-  timestamp: 1620240338595
-- platform: linux-64
+- kind: conda
   name: snowballstemmer
   version: 2.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2
-  url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4d22a9315e78c6827f806065957d566e
-    sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 58824
-  timestamp: 1637143137377
-- platform: win-64
-  name: snowballstemmer
-  version: 2.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2
-  url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4d22a9315e78c6827f806065957d566e
-    sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2
+  sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+  md5: 4d22a9315e78c6827f806065957d566e
+  depends:
+  - python >=2
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 58824
   timestamp: 1637143137377
-- platform: linux-64
+- kind: conda
   name: sphinx
   version: 7.2.6
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.2.6-pyhd8ed1ab_0.conda
+  sha256: 665d1fe6d20c6cc672ff20e6ebb405860f878b487d3d8d86a5952733fb7bbc42
+  md5: bbfd1120d1824d2d073bc65935f0e4c0
+  depends:
   - alabaster >=0.7,<0.8
   - babel >=2.9
   - colorama >=0.4.5
@@ -4530,541 +3113,237 @@ package:
   - sphinxcontrib-jsmath
   - sphinxcontrib-qthelp
   - sphinxcontrib-serializinghtml >=1.1.9
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.2.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbfd1120d1824d2d073bc65935f0e4c0
-    sha256: 665d1fe6d20c6cc672ff20e6ebb405860f878b487d3d8d86a5952733fb7bbc42
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 1281207
   timestamp: 1694647544854
-- platform: win-64
-  name: sphinx
-  version: 7.2.6
-  category: main
-  manager: conda
-  dependencies:
-  - alabaster >=0.7,<0.8
-  - babel >=2.9
-  - colorama >=0.4.5
-  - docutils >=0.18.1,<0.21
-  - imagesize >=1.3
-  - importlib-metadata >=4.8
-  - jinja2 >=3.0
-  - packaging >=21.0
-  - pygments >=2.14
-  - python >=3.9
-  - requests >=2.25.0
-  - snowballstemmer >=2.0
-  - sphinxcontrib-applehelp
-  - sphinxcontrib-devhelp
-  - sphinxcontrib-htmlhelp >=2.0.0
-  - sphinxcontrib-jsmath
-  - sphinxcontrib-qthelp
-  - sphinxcontrib-serializinghtml >=1.1.9
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx-7.2.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: bbfd1120d1824d2d073bc65935f0e4c0
-    sha256: 665d1fe6d20c6cc672ff20e6ebb405860f878b487d3d8d86a5952733fb7bbc42
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 1281207
-  timestamp: 1694647544854
-- platform: linux-64
+- kind: conda
   name: sphinxcontrib-applehelp
   version: 1.0.7
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.7-pyhd8ed1ab_0.conda
+  sha256: 67e2b386c7b3c858ead88fa71fe4fa5eb1f4f59d7994d167b3910a744db392d3
+  md5: aebfabcb60c33a89c1f9290cab49bc93
+  depends:
   - python >=3.9
   - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: aebfabcb60c33a89c1f9290cab49bc93
-    sha256: 67e2b386c7b3c858ead88fa71fe4fa5eb1f4f59d7994d167b3910a744db392d3
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 29367
   timestamp: 1692039716106
-- platform: win-64
-  name: sphinxcontrib-applehelp
-  version: 1.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.7-pyhd8ed1ab_0.conda
-  hash:
-    md5: aebfabcb60c33a89c1f9290cab49bc93
-    sha256: 67e2b386c7b3c858ead88fa71fe4fa5eb1f4f59d7994d167b3910a744db392d3
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 29367
-  timestamp: 1692039716106
-- platform: linux-64
+- kind: conda
   name: sphinxcontrib-devhelp
   version: 1.0.5
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.5-pyhd8ed1ab_0.conda
+  sha256: 770e13ebfef321426c09ec51d95c57755512db160518b2922a4337546ee51672
+  md5: ebf08f5184d8eaa486697bc060031953
+  depends:
   - python >=3.9
   - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: ebf08f5184d8eaa486697bc060031953
-    sha256: 770e13ebfef321426c09ec51d95c57755512db160518b2922a4337546ee51672
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 24551
   timestamp: 1692039743416
-- platform: win-64
-  name: sphinxcontrib-devhelp
-  version: 1.0.5
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: ebf08f5184d8eaa486697bc060031953
-    sha256: 770e13ebfef321426c09ec51d95c57755512db160518b2922a4337546ee51672
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 24551
-  timestamp: 1692039743416
-- platform: linux-64
+- kind: conda
   name: sphinxcontrib-htmlhelp
   version: 2.0.4
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.4-pyhd8ed1ab_0.conda
+  sha256: 5f09cd4a08a6c194c11999871a8c7cedc2cd7edd9ff7ceb6f0667b6698be4cc5
+  md5: a9a89000dfd19656ad004b937eeb6828
+  depends:
   - python >=3.9
   - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: a9a89000dfd19656ad004b937eeb6828
-    sha256: 5f09cd4a08a6c194c11999871a8c7cedc2cd7edd9ff7ceb6f0667b6698be4cc5
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 32872
   timestamp: 1692039732575
-- platform: win-64
-  name: sphinxcontrib-htmlhelp
-  version: 2.0.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: a9a89000dfd19656ad004b937eeb6828
-    sha256: 5f09cd4a08a6c194c11999871a8c7cedc2cd7edd9ff7ceb6f0667b6698be4cc5
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 32872
-  timestamp: 1692039732575
-- platform: linux-64
+- kind: conda
   name: sphinxcontrib-jsmath
   version: 1.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: da1d979339e2714c30a8e806a33ec087
-    sha256: d4337d83b8edba688547766fc80f1ac86d6ec86ceeeda93f376acc04079c5ce2
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
+  sha256: d4337d83b8edba688547766fc80f1ac86d6ec86ceeeda93f376acc04079c5ce2
+  md5: da1d979339e2714c30a8e806a33ec087
+  depends:
+  - python >=3.5
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 10431
   timestamp: 1691604844204
-- platform: win-64
-  name: sphinxcontrib-jsmath
-  version: 1.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: da1d979339e2714c30a8e806a33ec087
-    sha256: d4337d83b8edba688547766fc80f1ac86d6ec86ceeeda93f376acc04079c5ce2
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 10431
-  timestamp: 1691604844204
-- platform: linux-64
+- kind: conda
   name: sphinxcontrib-qthelp
   version: 1.0.6
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.6-pyhd8ed1ab_0.conda
+  sha256: 9ba5cea9cbab64106e8b5a9b19add855dcb52b8fbb1674398c715bccdbc04471
+  md5: cf5c9649272c677a964a7313279e3a9b
+  depends:
   - python >=3.9
   - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf5c9649272c677a964a7313279e3a9b
-    sha256: 9ba5cea9cbab64106e8b5a9b19add855dcb52b8fbb1674398c715bccdbc04471
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 26952
   timestamp: 1692039698081
-- platform: win-64
-  name: sphinxcontrib-qthelp
-  version: 1.0.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: cf5c9649272c677a964a7313279e3a9b
-    sha256: 9ba5cea9cbab64106e8b5a9b19add855dcb52b8fbb1674398c715bccdbc04471
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 26952
-  timestamp: 1692039698081
-- platform: linux-64
+- kind: conda
   name: sphinxcontrib-serializinghtml
   version: 1.1.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0612e497d7860728f2cda421ea2aec09
-    sha256: c5710ae7bb7465f25a29cc845d9fb6ad0ea561972d796d379fcb48d801e96d6d
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 28664
-  timestamp: 1692580110718
-- platform: win-64
-  name: sphinxcontrib-serializinghtml
-  version: 1.1.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  - sphinx >=5
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0612e497d7860728f2cda421ea2aec09
-    sha256: c5710ae7bb7465f25a29cc845d9fb6ad0ea561972d796d379fcb48d801e96d6d
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.9-pyhd8ed1ab_0.conda
+  sha256: c5710ae7bb7465f25a29cc845d9fb6ad0ea561972d796d379fcb48d801e96d6d
+  md5: 0612e497d7860728f2cda421ea2aec09
+  depends:
+  - python >=3.9
+  - sphinx >=5
+  arch: x86_64
+  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
   size: 28664
   timestamp: 1692580110718
-- platform: linux-64
+- kind: conda
   name: stack_data
   version: 0.6.2
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
+  sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+  md5: e7df0fdd404616638df5ece6e69ba7af
+  depends:
   - asttokens
   - executing
   - pure_eval
   - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 26205
   timestamp: 1669632203115
-- platform: win-64
-  name: stack_data
-  version: 0.6.2
-  category: main
-  manager: conda
-  dependencies:
-  - asttokens
-  - executing
-  - pure_eval
-  - python >=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 26205
-  timestamp: 1669632203115
-- platform: win-64
-  name: tbb
-  version: 2021.10.0
-  category: main
-  manager: conda
-  dependencies:
-  - libhwloc >=2.9.3,<2.9.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
-  hash:
-    md5: 5b8c97cf8f0e81d6c22c0bda9978790d
-    sha256: e55a2f1324f0fc8916ab8d590a3944ba1af62de727bb66e3019cf2744d26e679
-  build: h91493d7_2
-  arch: x86_64
-  subdir: win-64
-  build_number: 2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 156566
-  timestamp: 1697713986066
-- platform: linux-64
+- kind: conda
   name: tk
   version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  hash:
-    md5: d453b98d9c83e71da0741bb0ff4d76bc
-    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  build: noxft_h4845f30_101
-  arch: x86_64
-  subdir: linux-64
-  build_number: 101
-  license: TCL
-  license_family: BSD
-  size: 3318875
-  timestamp: 1699202167581
-- platform: win-64
-  name: tk
-  version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
-  hash:
-    md5: fc048363eb8f03cd1737600a5d08aafe
-    sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
   build: h5226925_1
-  arch: x86_64
-  subdir: win-64
   build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  arch: x86_64
+  platform: win
   license: TCL
   license_family: BSD
   size: 3503410
   timestamp: 1699202577803
-- platform: linux-64
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: noxft_h4845f30_101
+  build_number: 101
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: x86_64
+  platform: linux
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- kind: conda
   name: tomli
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  md5: 5844808ffab9ebdb694585b50ba02a96
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 15940
   timestamp: 1644342331069
-- platform: win-64
-  name: tomli
-  version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15940
-  timestamp: 1644342331069
-- platform: linux-64
+- kind: conda
   name: tqdm
   version: 4.66.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+  sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
+  md5: 03c97908b976498dcae97eb4e4f3149c
+  depends:
   - colorama
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 03c97908b976498dcae97eb4e4f3149c
-    sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MPL-2.0 or MIT
-  noarch: python
   size: 89449
   timestamp: 1691671387674
-- platform: win-64
-  name: tqdm
-  version: 4.66.1
-  category: main
-  manager: conda
-  dependencies:
-  - colorama
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 03c97908b976498dcae97eb4e4f3149c
-    sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MPL-2.0 or MIT
-  noarch: python
-  size: 89449
-  timestamp: 1691671387674
-- platform: linux-64
+- kind: conda
   name: traitlets
   version: 5.14.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 886f4a84ddb49b943b1697ac314e85b3
-    sha256: c32412029033264140926be474d327d7fd57c0d11db9b1745396b3d4db78a799
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 109927
-  timestamp: 1701095799725
-- platform: win-64
-  name: traitlets
-  version: 5.14.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 886f4a84ddb49b943b1697ac314e85b3
-    sha256: c32412029033264140926be474d327d7fd57c0d11db9b1745396b3d4db78a799
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.0-pyhd8ed1ab_0.conda
+  sha256: c32412029033264140926be474d327d7fd57c0d11db9b1745396b3d4db78a799
+  md5: 886f4a84ddb49b943b1697ac314e85b3
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 109927
   timestamp: 1701095799725
-- platform: linux-64
+- kind: conda
   name: twine
   version: 4.0.2
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/twine-4.0.2-pyhd8ed1ab_0.conda
+  sha256: 3e0c4f23d6a7d71783095b715f56c9f5f26feefaa9f30e27793dd12dc28e76c9
+  md5: e3a16168d6b9deefb8c1caa7943fb49e
+  depends:
   - importlib_metadata >=3.6
   - keyring >=15.1
   - pkginfo >=1.8.1
@@ -5075,482 +3354,264 @@ package:
   - rfc3986 >=1.4.0
   - rich >=12.0.0
   - urllib3 >=1.26.0
-  url: https://conda.anaconda.org/conda-forge/noarch/twine-4.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e3a16168d6b9deefb8c1caa7943fb49e
-    sha256: 3e0c4f23d6a7d71783095b715f56c9f5f26feefaa9f30e27793dd12dc28e76c9
-  build: pyhd8ed1ab_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: Apache-2.0
   license_family: Apache
-  noarch: python
   size: 30903
   timestamp: 1669898686321
-- platform: win-64
-  name: twine
-  version: 4.0.2
-  category: main
-  manager: conda
-  dependencies:
-  - importlib_metadata >=3.6
-  - keyring >=15.1
-  - pkginfo >=1.8.1
-  - python >=3.7
-  - readme_renderer >=35.0
-  - requests >=2.20
-  - requests-toolbelt >=0.8.0,!=0.9.0
-  - rfc3986 >=1.4.0
-  - rich >=12.0.0
-  - urllib3 >=1.26.0
-  url: https://conda.anaconda.org/conda-forge/noarch/twine-4.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e3a16168d6b9deefb8c1caa7943fb49e
-    sha256: 3e0c4f23d6a7d71783095b715f56c9f5f26feefaa9f30e27793dd12dc28e76c9
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 30903
-  timestamp: 1669898686321
-- platform: linux-64
+- kind: conda
   name: typing_extensions
   version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
   build: pyha770c72_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+  depends:
+  - python >=3.8
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 35108
   timestamp: 1695040948828
-- platform: win-64
-  name: typing_extensions
-  version: 4.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
-  hash:
-    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
-    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
-  build: pyha770c72_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  noarch: python
-  size: 35108
-  timestamp: 1695040948828
-- platform: linux-64
+- kind: conda
   name: tzdata
   version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
   build: h71feb2d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LicenseRef-Public-Domain
-  noarch: generic
-  size: 117580
-  timestamp: 1680041306008
-- platform: win-64
-  name: tzdata
-  version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  build: h71feb2d_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
-  license: LicenseRef-Public-Domain
   noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
+  arch: x86_64
+  platform: win
+  license: LicenseRef-Public-Domain
   size: 117580
   timestamp: 1680041306008
-- platform: win-64
+- kind: conda
   name: ucrt
   version: 10.0.22621.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
-  hash:
-    md5: 72608f6cd3e5898229c3ea16deb1ac43
-    sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
   build: h57928b3_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
   constrains:
   - vs2015_runtime >=14.29.30037
+  arch: x86_64
+  platform: win
   license: LicenseRef-Proprietary
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
-- platform: linux-64
+- kind: conda
   name: urllib3
   version: 2.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - brotli-python >=1.0.9
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 85324
-  timestamp: 1699933655057
-- platform: win-64
-  name: urllib3
-  version: 2.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - brotli-python >=1.0.9
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+  sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
+  md5: f8ced8ee63830dec7ecc1be048d1470a
+  depends:
+  - brotli-python >=1.0.9
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.7
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 85324
   timestamp: 1699933655057
-- platform: win-64
+- kind: conda
   name: vc
   version: '14.3'
-  category: main
-  manager: conda
-  dependencies:
-  - vc14_runtime >=14.36.32532
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
-  hash:
-    md5: 67ff6791f235bb606659bf2a5c169191
-    sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
   build: h64f974e_17
-  arch: x86_64
-  subdir: win-64
   build_number: 17
-  track_features: vc14
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+  sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
+  md5: 67ff6791f235bb606659bf2a5c169191
+  depends:
+  - vc14_runtime >=14.36.32532
+  arch: x86_64
+  platform: win
+  track_features:
+  - vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 17176
   timestamp: 1688020629925
-- platform: win-64
+- kind: conda
   name: vc14_runtime
   version: 14.36.32532
-  category: main
-  manager: conda
-  dependencies:
-  - ucrt >=10.0.20348.0
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
-  hash:
-    md5: d0de20f2f3fc806a81b44fcdd941aaf7
-    sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
   build: hdcecf7f_17
-  arch: x86_64
-  subdir: win-64
   build_number: 17
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+  sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
+  md5: d0de20f2f3fc806a81b44fcdd941aaf7
+  depends:
+  - ucrt >=10.0.20348.0
   constrains:
   - vs2015_runtime 14.36.32532.* *_17
+  arch: x86_64
+  platform: win
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
   size: 739437
   timestamp: 1694292382336
-- platform: win-64
+- kind: conda
   name: vs2015_runtime
   version: 14.36.32532
-  category: main
-  manager: conda
-  dependencies:
-  - vc14_runtime >=14.36.32532
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
-  hash:
-    md5: 4618046c39f7c81861e53ded842e738a
-    sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
   build: h05e6639_17
-  arch: x86_64
-  subdir: win-64
   build_number: 17
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+  sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
+  md5: 4618046c39f7c81861e53ded842e738a
+  depends:
+  - vc14_runtime >=14.36.32532
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 17207
   timestamp: 1688020635322
-- platform: linux-64
+- kind: conda
   name: wcwidth
   version: 0.2.12
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.12-pyhd8ed1ab_0.conda
-  hash:
-    md5: bf4a1d1a97ca27b0b65bacd9e238b484
-    sha256: ca757d0fc2dbd422af9d3238a8b4b630a6e11df3707a447bd89540656770d1d7
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.12-pyhd8ed1ab_0.conda
+  sha256: ca757d0fc2dbd422af9d3238a8b4b630a6e11df3707a447bd89540656770d1d7
+  md5: bf4a1d1a97ca27b0b65bacd9e238b484
+  depends:
+  - python >=3.8
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 32405
   timestamp: 1700608049984
-- platform: win-64
-  name: wcwidth
-  version: 0.2.12
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.12-pyhd8ed1ab_0.conda
-  hash:
-    md5: bf4a1d1a97ca27b0b65bacd9e238b484
-    sha256: ca757d0fc2dbd422af9d3238a8b4b630a6e11df3707a447bd89540656770d1d7
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 32405
-  timestamp: 1700608049984
-- platform: linux-64
+- kind: conda
   name: wheel
   version: 0.42.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
   build: pyhd8ed1ab_0
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+  sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+  md5: 1cdea58981c5cbc17b51973bcaddcea7
+  depends:
+  - python >=3.7
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 57553
   timestamp: 1701013309664
-- platform: win-64
-  name: wheel
-  version: 0.42.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 57553
-  timestamp: 1701013309664
-- platform: linux-64
+- kind: conda
   name: widgetsnbextension
   version: 4.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 82617d07b2f5f5a96296d3c19684b37a
-    sha256: 35dd47b3c117cd759ac46da0b69064bebccd94862e795615ee65dbbe3e6cd86b
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 885957
-  timestamp: 1694598840024
-- platform: win-64
-  name: widgetsnbextension
-  version: 4.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 82617d07b2f5f5a96296d3c19684b37a
-    sha256: 35dd47b3c117cd759ac46da0b69064bebccd94862e795615ee65dbbe3e6cd86b
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
+  sha256: 35dd47b3c117cd759ac46da0b69064bebccd94862e795615ee65dbbe3e6cd86b
+  md5: 82617d07b2f5f5a96296d3c19684b37a
+  depends:
+  - python >=3.7
+  arch: x86_64
+  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
   size: 885957
   timestamp: 1694598840024
-- platform: win-64
+- kind: conda
   name: win_inet_pton
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_6
+  build_number: 6
+  subdir: win-64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+  sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
+  md5: 30878ecc4bd36e8deeea1e3c151b2e0b
+  depends:
   - __win
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
-  hash:
-    md5: 30878ecc4bd36e8deeea1e3c151b2e0b
-    sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
-  build: pyhd8ed1ab_6
   arch: x86_64
-  subdir: win-64
-  build_number: 6
+  platform: win
   license: PUBLIC-DOMAIN
-  noarch: python
   size: 8191
   timestamp: 1667051294134
-- platform: linux-64
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-  hash:
-    md5: 2161070d867d1b1204ea749c8eec4ef0
-    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- platform: win-64
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies:
+  build: h8d14728_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
   - vc >=14.1,<15
   - vs2015_runtime >=14.16.27033
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
-  hash:
-    md5: 515d77642eaa3639413c6b1bc3f94219
-    sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-  build: h8d14728_0
   arch: x86_64
-  subdir: win-64
-  build_number: 0
+  platform: win
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
-- platform: linux-64
+- kind: conda
   name: zipp
   version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 18954
-  timestamp: 1695255262261
-- platform: win-64
-  name: zipp
-  version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: win-64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  arch: x86_64
+  platform: win
   license: MIT
   license_family: MIT
-  noarch: python
   size: 18954
   timestamp: 1695255262261
-- platform: linux-64
+- kind: conda
   name: zstd
   version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  hash:
-    md5: 04b88013080254850d6c01ed54810589
-    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  build: hfc55251_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 545199

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 name = "AnyPyTools"
 description = "Add a short description here"
 authors = ["Morten Enemark Lund <melund@gmail.com>"]
-channels = ["conda-forge"]
+channels = ["conda-forge", "anybody" ]
 platforms = ["win-64", "linux-64"]
 
 [tasks]
@@ -33,3 +33,8 @@ twine="*"
 # Test
 pytest="*"
 pytest-xdist = "*"
+
+
+[target.win-64.dependencies]
+anybody = "*"
+ #"file://D:/repos/anybody-recipe/output"

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,5 +36,5 @@ pytest-xdist = "*"
 
 
 [target.win-64.dependencies]
-anybody = "*"
+anybodycon = "*"
  #"file://D:/repos/anybody-recipe/output"


### PR DESCRIPTION
This PR prevents the pytest plugin from crashing pytest on machines where no AnyBody installation is found. 

It fails more grasefully now