### PR TITLE
Fix regression in winreg lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # AnyPyTools Change Log
 
+## v1.11.4
+
+**Fixed:**
+
+* Fix regression in windows registry lookup which caused AnyPyTools to crash.
+
+
 ## v1.11.3
 
 **Added:**

--- a/anypytools/__init__.py
+++ b/anypytools/__init__.py
@@ -37,7 +37,7 @@ __all__ = [
     "NORMAL_PRIORITY_CLASS",
 ]
 
-__version__ = "1.11.3"
+__version__ = "1.11.4"
 
 
 def print_versions():

--- a/anypytools/tools.py
+++ b/anypytools/tools.py
@@ -533,8 +533,8 @@ def lookup_anybody_in_registry() -> str | None:
     ]
     for key in keys_to_try:
         try:
-            value = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, key)
-        except WindowsError:
+            value = winreg.QueryValue(winreg.HKEY_CLASSES_ROOT, key)
+        except OSError:
             continue
         anybodypath = value.rsplit(" ", 1)[0].strip('"')
         return os.path.join(os.path.dirname(anybodypath), "AnyBodyCon.exe")


### PR DESCRIPTION
This pull request fixes a regression in the winreg lookup functionality that caused AnyPyTools to crash. The issue has been resolved by updating the winreg query method to use QueryValue instead of OpenKey.